### PR TITLE
Enable route matching for sites where WP lives in subdir

### DIFF
--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -148,20 +148,16 @@ class Rewrite_Rules_Inspector
 			$match_path = ltrim( $match_path, '/' );
 		}
 
+		$should_filter_by_source = ! empty( $_GET['source'] ) && 'all' !== $_GET[ 'source' ] && in_array( $_GET['source'], $this->sources );
+
 		// Filter based on match or source if necessary
 		foreach( $rewrite_rules_array as $rule => $data ) {
 			// If we're searching rules based on URL and there's no match, don't return it
 			if ( ! empty( $match_path ) && ! preg_match( "!^$rule!", $match_path ) ) {
 				unset( $rewrite_rules_array[$rule] );
-			}
-			// Filter by source if necessary
-			if ( isset( $_GET['source'] ) && in_array( $_GET['source'], $this->sources ) )
-				$filter_source = sanitize_key( $_GET['source'] );
-			else
-				$filter_source = 'all';
-			if ( $filter_source != 'all' && $rewrite_rules_array[$rule]['source'] != $filter_source )
+			} elseif ( $should_filter_by_source && $data['source'] != $_GET['source'] ) {
 				unset( $rewrite_rules_array[$rule] );
-			
+			}
 		}
 
 		// Return our array of rewrite rules to be used


### PR DESCRIPTION
Hello,

I've added ability to match routes when site is living in a subdir. Code for that is in the first commit, other 3 commits are optimizations IMHO.

Let me know if you need me to change anything before you accept the pull request. Thank you for sharing your software.
