### PR TITLE
Add a filter for rewrite rule source

### DIFF
--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -121,7 +121,7 @@ class Rewrite_Rules_Inspector
 				}
 			}
 			if ( !isset( $rewrite_rules_array[$rule]['source'] ) )
-				$rewrite_rules_array[$rule]['source'] = 'other';
+				$rewrite_rules_array[$rule]['source'] = apply_filters( 'rewrite_rules_inspector_source', 'other', $rule, $rewrite );
 		}
 
 		// Find any rewrite rules that should've been generated but weren't


### PR DESCRIPTION
Using a filter on the source for the rewrite rule allows us to specify something more descriptive then 'other' in certain cases, leading to better troubleshooting.

Addresses Issue #9
