### PR TITLE
Fix for strict standards error in declaration of Rewrite_Rules_Inspector_List_Table::single_row()

### DIFF
--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -420,17 +420,19 @@ class Rewrite_Rules_Inspector_List_Table extends WP_List_Table {
 	 */
 	function display_rows() {
 		foreach ( $this->items as $rewrite_rule => $rewrite_data ) {
-			$this->single_row( $rewrite_rule, $rewrite_data );
+			$rewrite_data['rule'] = $rewrite_rule;
+			$this->single_row( $rewrite_data );
 		}
 	}
 
 	/**
 	 * Display a single row of rewrite rule data
 	 */
-	function single_row( $rule, $data ) {
+	function single_row( $item ) {
 
-		$source = $data['source'];
-		$rewrite = $data['rewrite'];
+		$rule = $item['rule'];
+		$source = $item['source'];
+		$rewrite = $item['rewrite'];
 
 		$class = 'source-' . $source;
 


### PR DESCRIPTION
The current code causes an error in strict standards mode due to the method signature of `Rewrite_Rules_Inspector_List_Table::single_row()` not matching the parent `WP_List_Table::single_row($item)`.

I am running PHP 5.4.17 and the error is visible when WordPress debug mode is turned on.

This is the error thrown:

> Strict standards: Declaration of Rewrite_Rules_Inspector_List_Table::single_row() should be compatible with WP_List_Table::single_row($item) in ... /wp-content/plugins/rewrite-rules-inspector/rewrite-rules-inspector.php on line 298

I have fixed this by reverting the signature to a single `$item` to match the parent and passing the additional `$rule` information as an additional array entry in `$rewrite_data`
