### PR TITLE
Fix issue with negative lookarounds.

### DIFF
--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -162,7 +162,7 @@ class Rewrite_Rules_Inspector
 		// Filter based on match or source if necessary
 		foreach( $rewrite_rules_array as $rule => $data ) {
 			// If we're searching rules based on URL and there's no match, don't return it
-			if ( ! empty( $match_path ) && ! preg_match( "!^$rule!", $match_path ) ) {
+			if ( ! empty( $match_path ) && ! preg_match( "#^$rule#", $match_path ) ) {
 				unset( $rewrite_rules_array[$rule] );
 			} elseif ( $should_filter_by_source && $data['source'] != $_GET['source'] ) {
 				unset( $rewrite_rules_array[$rule] );


### PR DESCRIPTION
Negative lookarounds use the `!` character so we shouldn't use it as
a delimiter. Changed it to `#` as that's what Wordpress uses.

Fixes #18 