### PR TITLE
Remove call to deprecated `screen_icon()`

### DIFF
--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -205,7 +205,6 @@ class Rewrite_Rules_Inspector
 			}
 		</style>
 		<div class="wrap">
-		<?php screen_icon( 'tools' ); ?>
 		<h2><?php _e( 'Rewrite Rules Inspector', 'rewrite-rules-inspector' ); ?></h2>
 
 		<?php


### PR DESCRIPTION
* `screen_icon()` was "deprecated" in 3.8 to only output an HTML comment. https://core.trac.wordpress.org/changeset/26537
* It was deprecated for real in 4.9 (https://core.trac.wordpress.org/changeset/41274) and now generates a notice.