### PR TITLE
Increase minimum PHP version to 7.4 and WP version to 5.9

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -30,7 +30,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -39,7 +39,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="3.1"/>
+	<config name="minimum_supported_wp_version" value="5.9"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rewrite Rules Inspector
 
 Stable tag: 1.3.1  
-Requires at least: 3.1  
+Requires at least: 5.9  
 Tested up to: 5.7  
 Requires PHP: 7.4  
 License: GPLv2 or later  

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Stable tag: 1.3.1  
 Requires at least: 3.1  
 Tested up to: 5.7  
-Requires PHP: 5.6  
+Requires PHP: 7.4  
 License: GPLv2 or later  
 Tags: rewrite rules, tools  
 Contributors: danielbachhuber, automattic, tmoorewp, GaryJ

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Stable tag: 1.3.1  
 Requires at least: 5.9  
-Tested up to: 5.7  
+Tested up to: 6.5  
 Requires PHP: 7.4  
 License: GPLv2 or later  
 Tags: rewrite rules, tools  

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
 	"homepage": "https://wordpress.org/plugins/rewrite-rules-inspector/",
 	"license": "GPL-2.0-or-later",
 	"require": {
+		"php": ">=7.4",
 		"composer/installers": "^1.0"
 	}
 }

--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -19,7 +19,7 @@
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * GitHub Plugin URI: https://github.com/Automattic/Rewrite-Rules-Inspector
  * Requires PHP:      7.4
- * Requires WP:       3.1.0
+ * Requires WP:       5.9.0
  */
 
 define( 'REWRITE_RULES_INSPECTOR_VERSION', '1.3.1' ); // Unused for now.
@@ -42,19 +42,3 @@ add_action(
 		$rewrite_rules_inspector->run();
 	}
 );
-
-add_action( 'init', 'rri_load_textdomain' );
-/**
- * Load plugin textdomain.
- *
- * Only look for WP_LANG_DIR . '/plugins/rewrite-rules-inspector-' . $locale . '.mo'.
- * WP_LANG_DIR is usually WP_CONTENT_DIR . '/languages/'.
- * No other fallback location is supported.
- *
- * This can be removed once minimum supported WordPress is 4.6 or later.
- *
- * @since 1.3.1
- */
-function rri_load_textdomain() {
-	load_plugin_textdomain( 'rewrite-rules-inspector' );
-}

--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -18,7 +18,7 @@
  * License:           GPL-2.0-or-later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * GitHub Plugin URI: https://github.com/Automattic/Rewrite-Rules-Inspector
- * Requires PHP:      5.6
+ * Requires PHP:      7.4
  * Requires WP:       3.1.0
  */
 


### PR DESCRIPTION
While PHP 7.4 is above the current minimum version that WordPress core currently uses, it is still well within the range that the audience for this plugin is most likely using on their site.

Likewise, for the increase in WordPress 5.9, having WP 5.9 as a minimum keeps the structure greatly simplified should this plugin ever have automated tests.