### PR TITLE
CI: Refresh deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,19 @@
 name: Deploy to WordPress.org
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types: [released]
+  # Allow manual triggering of the workflow.
+  workflow_dispatch:
 jobs:
-  tag:
-    name: New tag
+  release:
+    name: New release to WordPress.org
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: WordPress Plugin Deploy
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Push to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:
+          SLUG: rewrite-rules-inspector
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          SLUG: rewrite-rules-inspector


### PR DESCRIPTION
- Use latest ubuntu version
- Use action/checkout v4
- Update step names
- Push on GH Release, not just a tag.

No immediate release needs to be done for this being merged into `main`, but it's then a little tidier whenever a future release is made.