### PR TITLE
Add Rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,9 @@
 		"php": ">=7.4",
 		"composer/installers": "^1 || ^2"
 	},
+	"require-dev": {
+		"rector/rector": "^1.2"
+	},
 	"config": {
 		"allow-plugins": {
 			"composer/installers": true

--- a/rector.php
+++ b/rector.php
@@ -34,6 +34,6 @@ return RectorConfig::configure()
 			ExplicitNullableParamTypeRector::class,
 		)
 	)
-	->withPreparedSets( deadCode: true/*, codeQuality: true, instanceOf: true, codingStyle: true */ )
+	->withPreparedSets( deadCode: true, codeQuality: true/*, instanceOf: true, codingStyle: true */ )
 	->withTypeCoverageLevel( 1 )
 	;

--- a/rector.php
+++ b/rector.php
@@ -35,5 +35,5 @@ return RectorConfig::configure()
 		)
 	)
 //	->withPreparedSets( deadCode: true, codeQuality: true, instanceOf: true, codingStyle: true )
-//	->withTypeCoverageLevel( 1 )
+	->withTypeCoverageLevel( 1 )
 	;

--- a/rector.php
+++ b/rector.php
@@ -2,8 +2,15 @@
 
 declare(strict_types=1);
 
+use Rector\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector;
+use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\StaticCall\RemoveParentCallWithoutParentRector;
 use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
+use Rector\Php80\Rector\Identical\StrEndsWithRector;
+use Rector\Php80\Rector\Identical\StrStartsWithRector;
+use Rector\Php80\Rector\NotIdentical\StrContainsRector;
+use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php82\Rector\Encapsed\VariableInStringInterpolationFixerRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
@@ -24,6 +31,18 @@ return RectorConfig::configure()
 	// Changes from later PHP Sets that are backwards compatible:
 	->withRules(
 		array(
+			// 8.0
+			ConsistentImplodeRector::class,
+			OptionalParametersAfterRequiredRector::class,
+			RemoveParentCallWithoutParentRector::class,
+			// Backfilled from PHP 8.0 into WP 5.9, so these can be used.
+			StrContainsRector::class,
+			StrEndsWithRector::class,
+			StrStartsWithRector::class,
+
+			// 8.1
+			NullToStrictStringFuncCallArgRector::class,
+
 			// 8.2
 			VariableInStringInterpolationFixerRector::class,
 

--- a/rector.php
+++ b/rector.php
@@ -20,20 +20,20 @@ return RectorConfig::configure()
 			LongArrayToShortArrayRector::class,
 		)
 	)
-	->withPhpSets( php71: true )
+	->withPhpSets( php74: true )
 	// Changes from later PHP Sets that are backwards compatible:
-//	->withRules(
-//		array(
-//			// 8.2
-//			VariableInStringInterpolationFixerRector::class,
-//
-//			// 8.3
-//			AddOverrideAttributeToOverriddenMethodsRector::class,
-//
-//			// 8.4
-//			ExplicitNullableParamTypeRector::class,
-//		)
-//	)
+	->withRules(
+		array(
+			// 8.2
+			VariableInStringInterpolationFixerRector::class,
+
+			// 8.3
+			AddOverrideAttributeToOverriddenMethodsRector::class,
+
+			// 8.4
+			ExplicitNullableParamTypeRector::class,
+		)
+	)
 //	->withPreparedSets( deadCode: true, codeQuality: true, instanceOf: true, codingStyle: true )
 //	->withTypeCoverageLevel( 1 )
 	;

--- a/rector.php
+++ b/rector.php
@@ -34,6 +34,6 @@ return RectorConfig::configure()
 			ExplicitNullableParamTypeRector::class,
 		)
 	)
-	->withPreparedSets( deadCode: true, codeQuality: true/*, instanceOf: true, codingStyle: true */ )
+	->withPreparedSets( deadCode: true, codeQuality: true, instanceOf: true, codingStyle: true )
 	->withTypeCoverageLevel( 1 )
 	;

--- a/rector.php
+++ b/rector.php
@@ -34,6 +34,6 @@ return RectorConfig::configure()
 			ExplicitNullableParamTypeRector::class,
 		)
 	)
-//	->withPreparedSets( deadCode: true, codeQuality: true, instanceOf: true, codingStyle: true )
+	->withPreparedSets( deadCode: true/*, codeQuality: true, instanceOf: true, codingStyle: true */ )
 	->withTypeCoverageLevel( 1 )
 	;

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Php82\Rector\Encapsed\VariableInStringInterpolationFixerRector;
+use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
+
+return RectorConfig::configure()
+	->withPaths(
+		array(
+			__DIR__ . '/src',
+			__DIR__ . '/rewrite-rules-inspector.php',
+		)
+	)
+	->withSkip(
+		array(
+			LongArrayToShortArrayRector::class,
+		)
+	)
+	->withPhpSets( php54: true )
+	// Changes from later PHP Sets that are backwards compatible:
+//	->withRules(
+//		array(
+//			// 8.2
+//			VariableInStringInterpolationFixerRector::class,
+//
+//			// 8.3
+//			AddOverrideAttributeToOverriddenMethodsRector::class,
+//
+//			// 8.4
+//			ExplicitNullableParamTypeRector::class,
+//		)
+//	)
+//	->withPreparedSets( deadCode: true, codeQuality: true, instanceOf: true, codingStyle: true )
+//	->withTypeCoverageLevel( 1 )
+	;

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php54\Rector\Array_\LongArrayToShortArrayRector;
 use Rector\Php82\Rector\Encapsed\VariableInStringInterpolationFixerRector;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
 use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
@@ -19,7 +20,7 @@ return RectorConfig::configure()
 			LongArrayToShortArrayRector::class,
 		)
 	)
-	->withPhpSets( php54: true )
+	->withPhpSets( php71: true )
 	// Changes from later PHP Sets that are backwards compatible:
 //	->withRules(
 //		array(

--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -36,7 +36,7 @@ require __DIR__ . '/src/class-rewrite-rules-inspector-list-table.php';
 
 add_action(
 	'plugins_loaded',
-	function() {
+	function(): void {
 		global $rewrite_rules_inspector;
 		$rewrite_rules_inspector = new Rewrite_Rules_Inspector();
 		$rewrite_rules_inspector->run();

--- a/src/class-rewrite-rules-inspector-list-table.php
+++ b/src/class-rewrite-rules-inspector-list-table.php
@@ -82,8 +82,8 @@ class Rewrite_Rules_Inspector_List_Table extends WP_List_Table {
 					$flush_url = add_query_arg( $args, menu_page_url( $plugin_page, false ) );
 					?>
 					<a title="<?php esc_attr_e( 'Flush your rewrite rules to regenerate them', 'rewrite-rules-inspector' ); ?>" class="button-secondary" href="<?php echo esc_url( $flush_url ); ?>"><?php esc_html_e( 'Flush Rules', 'rewrite-rules-inspector' ); ?></a>
-				<?php endif; ?>
-				<?php
+				<?php endif;
+
 				// Prepare the link to download a set of rules.
 				// Link is contingent on the current filter state.
 				$args = array(
@@ -95,6 +95,7 @@ class Rewrite_Rules_Inspector_List_Table extends WP_List_Table {
 				if ( isset( $_GET['source'] ) && in_array( $_GET['source'], $rewrite_rules_inspector->sources, true ) ) {
 					$args['source'] = sanitize_key( $_GET['source'] );
 				}
+
 				$args['s'] = empty( $_GET['s'] ) ? '' : sanitize_text_field( $_GET['s'] );
 
 				$download_url = add_query_arg( $args, menu_page_url( $plugin_page, false ) );
@@ -112,6 +113,7 @@ class Rewrite_Rules_Inspector_List_Table extends WP_List_Table {
 					if ( isset( $_GET['source'] ) && in_array( $_GET['source'], $rewrite_rules_inspector->sources, true ) ) {
 						$filter_source = sanitize_key( $_GET['source'] );
 					}
+
 					foreach ( $rewrite_rules_inspector->sources as $value ) {
 						echo '<option value="' . esc_attr( $value ) . '" ';
 						selected( $filter_source, $value );
@@ -122,7 +124,8 @@ class Rewrite_Rules_Inspector_List_Table extends WP_List_Table {
 				<?php submit_button( __( 'Filter', 'rewrite-rules-inspector' ), 'primary', null, false ); ?>
 				<?php if ( $search || ! empty( $_GET['source'] ) ) : ?>
 					<a href="<?php echo esc_url( menu_page_url( $plugin_page, false ) ); ?>" class="button-secondary"><?php esc_html_e( 'Reset', 'rewrite-rules-inspector' ); ?></a>
-				<?php endif; ?>
+				<?php endif;
+      		?>
 			</form>
 		</div>
 		<?php

--- a/src/class-rewrite-rules-inspector-list-table.php
+++ b/src/class-rewrite-rules-inspector-list-table.php
@@ -60,7 +60,7 @@ class Rewrite_Rules_Inspector_List_Table extends WP_List_Table {
 	public function display_tablenav( $which ) {
 		global $plugin_page, $rewrite_rules_inspector;
 
-		$search = ! empty( $_GET['s'] ) ? sanitize_text_field( $_GET['s'] ) : '';
+		$search = empty( $_GET['s'] ) ? '' : sanitize_text_field( $_GET['s'] );
 
 		if ( 'bottom' === $which ) {
 			return false;
@@ -95,7 +95,7 @@ class Rewrite_Rules_Inspector_List_Table extends WP_List_Table {
 				if ( isset( $_GET['source'] ) && in_array( $_GET['source'], $rewrite_rules_inspector->sources, true ) ) {
 					$args['source'] = sanitize_key( $_GET['source'] );
 				}
-				$args['s'] = ! empty( $_GET['s'] ) ? sanitize_text_field( $_GET['s'] ) : '';
+				$args['s'] = empty( $_GET['s'] ) ? '' : sanitize_text_field( $_GET['s'] );
 
 				$download_url = add_query_arg( $args, menu_page_url( $plugin_page, false ) );
 				?>
@@ -126,6 +126,7 @@ class Rewrite_Rules_Inspector_List_Table extends WP_List_Table {
 			</form>
 		</div>
 		<?php
+		return true;
 	}
 
 	/**

--- a/src/class-rewrite-rules-inspector-list-table.php
+++ b/src/class-rewrite-rules-inspector-list-table.php
@@ -169,7 +169,7 @@ class Rewrite_Rules_Inspector_List_Table extends WP_List_Table {
 
 		echo '<tr class="', esc_attr( $class ), '">';
 
-		list( $columns, $hidden ) = $this->get_column_info();
+		[$columns, $hidden] = $this->get_column_info();
 
 		foreach ( $columns as $column_name => $column_display_name ) {
 			switch ( $column_name ) {

--- a/src/class-rewrite-rules-inspector.php
+++ b/src/class-rewrite-rules-inspector.php
@@ -117,6 +117,7 @@ class Rewrite_Rules_Inspector {
 		if ( ! $rewrite_rules ) {
 			$rewrite_rules = array();
 		}
+
 		// Track down which rewrite rules are associated with which methods by breaking it down.
 		$rewrite_rules_by_source             = array();
 		$rewrite_rules_by_source['post']     = $wp_rewrite->generate_rewrite_rules( $wp_rewrite->permalink_structure, EP_PERMALINK );
@@ -158,6 +159,7 @@ class Rewrite_Rules_Inspector {
 					$rewrite_rules_array[ $rule ]['source'] = $source;
 				}
 			}
+
 			if ( ! isset( $rewrite_rules_array[ $rule ]['source'] ) ) {
 				$rewrite_rules_array[ $rule ]['source'] = apply_filters( 'rewrite_rules_inspector_source', 'other', $rule, $rewrite );
 			}
@@ -174,6 +176,7 @@ class Rewrite_Rules_Inspector {
 				);
 			}
 		}
+
 		// Prepend rules so it's obvious.
 		$rewrite_rules_array = array_reverse( $rewrite_rules_array, true );
 
@@ -184,6 +187,7 @@ class Rewrite_Rules_Inspector {
 		foreach ( $rewrite_rules_array as $rule => $data ) {
 			$sources[] = $data['source'];
 		}
+
 		$this->sources = array_unique( $sources );
 
 		if ( ! empty( $_GET['s'] ) ) {
@@ -192,6 +196,7 @@ class Rewrite_Rules_Inspector {
 			if ( ! empty( $wordpress_subdir_for_site ) ) {
 				$match_path = str_replace( $wordpress_subdir_for_site, '', $match_path );
 			}
+
 			$match_path = ltrim( $match_path, '/' );
 		}
 
@@ -200,7 +205,7 @@ class Rewrite_Rules_Inspector {
 		// Filter based on match or source if necessary.
 		foreach ( $rewrite_rules_array as $rule => $data ) {
 			// If we're searching rules based on URL and there's no match, don't return it.
-			if ( $match_path !== '' && $match_path !== '0' && ! preg_match( "#^$rule#", $match_path ) ) {
+			if ( $match_path !== '' && $match_path !== '0' && ! preg_match( sprintf('#^%s#', $rule), $match_path ) ) {
 				unset( $rewrite_rules_array[ $rule ] );
 			} elseif ( $should_filter_by_source && $data['source'] !== $_GET['source'] ) {
 				unset( $rewrite_rules_array[ $rule ] );
@@ -279,10 +284,10 @@ class Rewrite_Rules_Inspector {
 					printf( esc_html__( 'A listing of all %1$s rewrite rules for this site.', 'rewrite-rules-inspector' ), count( $wp_list_table->items ) );
 					?>
 				</p>
-			<?php endif; ?>
+			<?php endif;
 
-			<?php $wp_list_table->display(); ?>
-
+			$wp_list_table->display();
+			?>
 		</div>
 		<?php
 	}
@@ -314,6 +319,7 @@ class Rewrite_Rules_Inspector {
 		foreach ( $rewrite_rules as $rule => $data ) {
 			$rules_to_export[ $rule ] = $data['rewrite'];
 		}
+
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped,WordPress.PHP.DevelopmentFunctions.error_log_var_export
 		echo var_export( $rules_to_export, true );
 		exit;

--- a/src/class-rewrite-rules-inspector.php
+++ b/src/class-rewrite-rules-inspector.php
@@ -165,7 +165,6 @@ class Rewrite_Rules_Inspector {
 
 		// Find any rewrite rules that should've been generated but weren't.
 		$maybe_missing       = $wp_rewrite->rewrite_rules();
-		$missing_rules       = array();
 		$rewrite_rules_array = array_reverse( $rewrite_rules_array, true );
 		foreach ( $maybe_missing as $rule => $rewrite ) {
 			if ( ! array_key_exists( $rule, $rewrite_rules_array ) ) {

--- a/src/class-rewrite-rules-inspector.php
+++ b/src/class-rewrite-rules-inspector.php
@@ -200,7 +200,7 @@ class Rewrite_Rules_Inspector {
 		// Filter based on match or source if necessary.
 		foreach ( $rewrite_rules_array as $rule => $data ) {
 			// If we're searching rules based on URL and there's no match, don't return it.
-			if ( ! empty( $match_path ) && ! preg_match( "#^$rule#", $match_path ) ) {
+			if ( $match_path !== '' && $match_path !== '0' && ! preg_match( "#^$rule#", $match_path ) ) {
 				unset( $rewrite_rules_array[ $rule ] );
 			} elseif ( $should_filter_by_source && $data['source'] !== $_GET['source'] ) {
 				unset( $rewrite_rules_array[ $rule ] );


### PR DESCRIPTION
Rector is a PHP QA tool for refactoring code. In this case, we're using it to modernise the code where PHP 7.4 is the minimum supported version.

Adding this means we make it easier to update code when a higher minimum supported version is used too.

See individual commits for a more readable breakdown of the changes.

After `composer update`, it requires the developer to use PHP 8.0 or later to run `vector/bin/rector` with the config found in `rector.php`.