### PR TITLE
feat: Add permastructs table with descriptions and structures

### DIFF
--- a/src/class-rewrite-rules-inspector.php
+++ b/src/class-rewrite-rules-inspector.php
@@ -105,6 +105,118 @@ class Rewrite_Rules_Inspector {
 	}
 
 	/**
+	 * Get all permastructs that WordPress is aware of.
+	 *
+	 * @since 1.5.0
+	 * @return array Array of permastructs with their names and structures.
+	 */
+	public function get_permastructs() {
+		global $wp_rewrite;
+
+		$permastructs = array();
+
+		// Core permastructs.
+		$permastructs['post'] = array(
+			'name'        => __( 'Post Permalink', 'rewrite-rules-inspector' ),
+			'structure'   => $wp_rewrite->permalink_structure,
+			'description' => __( 'The permalink structure for posts', 'rewrite-rules-inspector' ),
+		);
+
+		$permastructs['date'] = array(
+			'name'        => __( 'Date Archive', 'rewrite-rules-inspector' ),
+			'structure'   => $wp_rewrite->get_date_permastruct(),
+			'description' => __( 'The permalink structure for date archives', 'rewrite-rules-inspector' ),
+		);
+
+		$permastructs['search'] = array(
+			'name'        => __( 'Search Results', 'rewrite-rules-inspector' ),
+			'structure'   => $wp_rewrite->get_search_permastruct(),
+			'description' => __( 'The permalink structure for search results', 'rewrite-rules-inspector' ),
+		);
+
+		$permastructs['author'] = array(
+			'name'        => __( 'Author Archive', 'rewrite-rules-inspector' ),
+			'structure'   => $wp_rewrite->get_author_permastruct(),
+			'description' => __( 'The permalink structure for author archives', 'rewrite-rules-inspector' ),
+		);
+
+		$permastructs['comments'] = array(
+			'name'        => __( 'Comments', 'rewrite-rules-inspector' ),
+			'structure'   => $wp_rewrite->root . $wp_rewrite->comments_base,
+			'description' => __( 'The permalink structure for comments', 'rewrite-rules-inspector' ),
+		);
+
+		$permastructs['root'] = array(
+			'name'        => __( 'Root', 'rewrite-rules-inspector' ),
+			'structure'   => $wp_rewrite->root . '/',
+			'description' => __( 'The root permalink structure', 'rewrite-rules-inspector' ),
+		);
+
+		// Extra permastructs including tags, categories, etc.
+		foreach ( $wp_rewrite->extra_permastructs as $permastructname => $permastruct ) {
+			$structure = '';
+			if ( is_array( $permastruct ) ) {
+				// Pre 3.4 compat.
+				if ( count( $permastruct ) === 2 ) {
+					$structure = $permastruct[0];
+				} else {
+					$structure = $permastruct['struct'] ?? '';
+				}
+			} else {
+				$structure = $permastruct;
+			}
+
+			// Generate human-readable names and descriptions.
+			$name        = ucwords( str_replace( array( '_', '-' ), ' ', $permastructname ) );
+			/* translators: %s: permastruct name */
+			$description = sprintf( __( 'The permalink structure for %s', 'rewrite-rules-inspector' ), strtolower( $name ) );
+
+			// Special cases for common permastructs.
+			switch ( $permastructname ) {
+				case 'category':
+					$name        = __( 'Category Archive', 'rewrite-rules-inspector' );
+					$description = __( 'The permalink structure for category archives', 'rewrite-rules-inspector' );
+					break;
+				case 'post_tag':
+					$name        = __( 'Tag Archive', 'rewrite-rules-inspector' );
+					$description = __( 'The permalink structure for tag archives', 'rewrite-rules-inspector' );
+					break;
+				case 'post_format':
+					$name        = __( 'Post Format Archive', 'rewrite-rules-inspector' );
+					$description = __( 'The permalink structure for post format archives', 'rewrite-rules-inspector' );
+					break;
+				case 'test_custom':
+					$name        = __( 'Test Custom (Demo)', 'rewrite-rules-inspector' );
+					$description = __( 'A custom permastruct added for testing the permastructs display feature', 'rewrite-rules-inspector' );
+					break;
+				case 'demo_archive':
+					$name        = __( 'Demo Archive (Test)', 'rewrite-rules-inspector' );
+					$description = __( 'A demo archive permastruct with date-based structure for testing', 'rewrite-rules-inspector' );
+					break;
+			}
+
+			$permastructs[ $permastructname ] = array(
+				'name'        => $name,
+				'structure'   => $structure,
+				'description' => $description,
+			);
+		}
+
+		// Filter out empty structures.
+		$permastructs = array_filter(
+			$permastructs,
+			function ( $permastruct ) {
+				return ! empty( $permastruct['structure'] );
+			}
+		);
+
+		// Allow filtering of permastructs.
+		$permastructs = apply_filters( 'rri_permastructs', $permastructs );
+
+		return $permastructs;
+	}
+
+	/**
 	 * Get the rewrite rules for the current view.
 	 *
 	 * @since 1.0.0
@@ -250,15 +362,38 @@ class Rewrite_Rules_Inspector {
 				border-top-color: #fecfd0;
 				border-bottom-color: #f99b9d;
 			}
+			#permastructs-section {
+				margin-top: 30px;
+			}
+			.permastruct-structure {
+				font-family: monospace;
+				background: #f6f7f7;
+				padding: 2px 6px;
+				border-radius: 3px;
+				font-size: 13px;
+			}
 		</style>
 		<div class="wrap">
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 
 			<?php
+			// Get permastructs for jump link.
+			$permastructs = $this->get_permastructs();
+			?>
+
+			<h2 id="rewrite-rules-section"><?php esc_html_e( 'Rewrite Rules', 'rewrite-rules-inspector' ); ?></h2>
+			
+			<?php if ( ! empty( $permastructs ) ) : ?>
+				<p>
+					<a href="#permastructs-section"><?php esc_html_e( 'Jump to Permastructs', 'rewrite-rules-inspector' ); ?></a>
+				</p>
+			<?php endif; ?>
+
+			<?php
 			$missing_count = 0;
 			foreach ( $rules as $rule ) {
 				if ( 'missing' === $rule['source'] ) {
-					$missing_count++;
+					++$missing_count;
 				}
 			}
 
@@ -286,10 +421,90 @@ class Rewrite_Rules_Inspector {
 					printf( esc_html__( 'A listing of all %1$s rewrite rules for this site.', 'rewrite-rules-inspector' ), count( $wp_list_table->items ) );
 					?>
 				</p>
-			<?php endif;
+			<?php endif; ?>
 
-			$wp_list_table->display();
-			?>
+			<?php $wp_list_table->display(); ?>
+
+			<?php if ( ! empty( $permastructs ) ) : ?>
+				<h2 id="permastructs-section"><?php esc_html_e( 'Permastructs', 'rewrite-rules-inspector' ); ?></h2>
+				
+				<p>
+					<?php
+					/* translators: %d: Count of permastructs */
+					printf( esc_html__( 'A listing of all %d permastructs that WordPress is aware of.', 'rewrite-rules-inspector' ), count( $permastructs ) );
+					?>
+					<a href="#rewrite-rules-section"><?php esc_html_e( 'Jump to Rewrite Rules', 'rewrite-rules-inspector' ); ?></a>
+				</p>
+
+				<?php
+				// Create a simple list table for permastructs.
+				$permastructs_table = new WP_List_Table(
+					array(
+						'singular' => 'Permastruct',
+						'plural'   => 'Permastructs',
+					)
+				);
+
+				// Set up the columns.
+				$permastructs_table->_column_headers = array(
+					array(
+						'name'        => __( 'Name', 'rewrite-rules-inspector' ),
+						'structure'   => __( 'Structure', 'rewrite-rules-inspector' ),
+						'description' => __( 'Description', 'rewrite-rules-inspector' ),
+					),
+					array(),
+					array(),
+				);
+
+				// Set the items.
+				$permastructs_table->items = $permastructs;
+
+				// Display the table.
+				?>
+				<table class="wp-list-table widefat fixed striped">
+					<thead>
+						<tr>
+							<th scope="col" class="manage-column column-name column-primary">
+								<?php esc_html_e( 'Name', 'rewrite-rules-inspector' ); ?>
+							</th>
+							<th scope="col" class="manage-column column-structure">
+								<?php esc_html_e( 'Structure', 'rewrite-rules-inspector' ); ?>
+							</th>
+							<th scope="col" class="manage-column column-description">
+								<?php esc_html_e( 'Description', 'rewrite-rules-inspector' ); ?>
+							</th>
+						</tr>
+					</thead>
+					<tbody id="the-list">
+						<?php foreach ( $permastructs as $permastruct ) : ?>
+							<tr>
+								<td class="name column-name column-primary">
+									<strong><?php echo esc_html( $permastruct['name'] ); ?></strong>
+								</td>
+								<td class="structure column-structure">
+									<code class="permastruct-structure"><?php echo esc_html( $permastruct['structure'] ); ?></code>
+								</td>
+								<td class="description column-description">
+									<?php echo esc_html( $permastruct['description'] ); ?>
+								</td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+					<tfoot>
+						<tr>
+							<th scope="col" class="manage-column column-name column-primary">
+								<?php esc_html_e( 'Name', 'rewrite-rules-inspector' ); ?>
+							</th>
+							<th scope="col" class="manage-column column-structure">
+								<?php esc_html_e( 'Structure', 'rewrite-rules-inspector' ); ?>
+							</th>
+							<th scope="col" class="manage-column column-description">
+								<?php esc_html_e( 'Description', 'rewrite-rules-inspector' ); ?>
+							</th>
+						</tr>
+					</tfoot>
+				</table>
+			<?php endif; ?>
 		</div>
 		<?php
 	}

--- a/src/class-rewrite-rules-inspector.php
+++ b/src/class-rewrite-rules-inspector.php
@@ -92,7 +92,10 @@ class Rewrite_Rules_Inspector {
 	 * @since 1.0.0
 	 */
 	public function action_admin_menu() {
-		add_submenu_page( $this->parent_slug, __( 'Rewrite Rules Inspector', 'rewrite-rules-inspector' ), __( 'Rewrite Rules', 'rewrite-rules-inspector' ), $this->view_cap, $this->page_slug, array( $this, 'view_rules' ) );
+		$hook = add_submenu_page( $this->parent_slug, __( 'Rewrite Rules Inspector', 'rewrite-rules-inspector' ), __( 'Rewrite Rules', 'rewrite-rules-inspector' ), $this->view_cap, $this->page_slug, array( $this, 'view_rules' ) );
+		
+		// Add screen help.
+		add_action( 'load-' . $hook, array( $this, 'add_screen_help' ) );
 	}
 
 	/**
@@ -102,6 +105,86 @@ class Rewrite_Rules_Inspector {
 	 */
 	public function action_admin_notices() {
 		echo '<div class="message updated"><p>' . esc_html__( 'Rewrite rules flushed.', 'rewrite-rules-inspector' ) . '</p></div>';
+	}
+
+	/**
+	 * Add screen help tabs to explain rewrite rules and permastructs.
+	 *
+	 * @since 1.5.0
+	 */
+	public function add_screen_help() {
+		$screen = get_current_screen();
+		
+		// Overview tab.
+		$screen->add_help_tab(
+			array(
+				'id'      => 'overview',
+				'title'   => __( 'Overview', 'rewrite-rules-inspector' ),
+				'content' => '<p>' . __( 'The Rewrite Rules Inspector helps you understand and debug your WordPress site\'s URL structure. It shows you all the rewrite rules and permastructs that WordPress uses to handle URLs.', 'rewrite-rules-inspector' ) . '</p>',
+			)
+		);
+		
+		// Rewrite Rules tab.
+		$screen->add_help_tab(
+			array(
+				'id'      => 'rewrite-rules',
+				'title'   => __( 'Rewrite Rules', 'rewrite-rules-inspector' ),
+				'content' => '<p>' . __( '<strong>Rewrite Rules</strong> are the actual URL patterns that WordPress uses to match incoming requests and determine what content to display.', 'rewrite-rules-inspector' ) . '</p>' .
+					'<p>' . __( 'Each rule consists of:', 'rewrite-rules-inspector' ) . '</p>' .
+					'<ul>' .
+					'<li>' . __( '<strong>Rule:</strong> A regular expression pattern that matches URLs (e.g., <code>^category/([^/]+)/?$</code>)', 'rewrite-rules-inspector' ) . '</li>' .
+					'<li>' . __( '<strong>Rewrite:</strong> The internal WordPress query that gets executed (e.g., <code>index.php?category_name=$matches[1]</code>)', 'rewrite-rules-inspector' ) . '</li>' .
+					'<li>' . __( '<strong>Source:</strong> Where the rule comes from (e.g., category, post, custom permastruct)', 'rewrite-rules-inspector' ) . '</li>' .
+					'</ul>' .
+					'<p>' . __( 'When someone visits a URL, WordPress checks these rules in order until it finds a match, then executes the corresponding rewrite to determine what content to show.', 'rewrite-rules-inspector' ) . '</p>',
+			)
+		);
+		
+		// Permastructs tab.
+		$screen->add_help_tab(
+			array(
+				'id'      => 'permastructs',
+				'title'   => __( 'Permastructs', 'rewrite-rules-inspector' ),
+				'content' => '<p>' . __( '<strong>Permastructs</strong> are the URL structure templates that define how different types of content should be accessed via URLs.', 'rewrite-rules-inspector' ) . '</p>' .
+					'<p>' . __( 'For example:', 'rewrite-rules-inspector' ) . '</p>' .
+					'<ul>' .
+					'<li>' . __( '<strong>Post Permalink:</strong> <code>/%year%/%monthnum%/%day%/%postname%/</code> - defines how individual posts are accessed', 'rewrite-rules-inspector' ) . '</li>' .
+					'<li>' . __( '<strong>Category Archive:</strong> <code>/category/%category%</code> - defines how category pages are accessed', 'rewrite-rules-inspector' ) . '</li>' .
+					'<li>' . __( '<strong>Tag Archive:</strong> <code>/tag/%post_tag%</code> - defines how tag pages are accessed', 'rewrite-rules-inspector' ) . '</li>' .
+					'</ul>' .
+					'<p>' . __( 'WordPress uses these permastructs to generate the actual rewrite rules. The permastructs are like blueprints, while the rewrite rules are the specific patterns that get created from those blueprints.', 'rewrite-rules-inspector' ) . '</p>' .
+					'<p>' . __( 'You can customize permastructs through WordPress settings (Settings → Permalinks) or by using WordPress functions like <code>add_permastruct()</code> in your theme or plugin.', 'rewrite-rules-inspector' ) . '</p>',
+			)
+		);
+		
+		// Troubleshooting tab.
+		$screen->add_help_tab(
+			array(
+				'id'      => 'troubleshooting',
+				'title'   => __( 'Troubleshooting', 'rewrite-rules-inspector' ),
+				'content' => '<p>' . __( '<strong>Common Issues:</strong>', 'rewrite-rules-inspector' ) . '</p>' .
+					'<ul>' .
+					'<li>' . __( '<strong>Missing Rules:</strong> If you see rules marked as "missing", try clicking the "Flush Rules" button to regenerate them.', 'rewrite-rules-inspector' ) . '</li>' .
+					'<li>' . __( '<strong>404 Errors:</strong> Check if the URL pattern exists in the rewrite rules. Use the "Match URL" filter to test specific URLs.', 'rewrite-rules-inspector' ) . '</li>' .
+					'<li>' . __( '<strong>Custom URLs Not Working:</strong> Verify that your custom permastruct is properly registered and that rewrite rules have been flushed.', 'rewrite-rules-inspector' ) . '</li>' .
+					'<li>' . __( '<strong>Plugin Conflicts:</strong> Some plugins may modify rewrite rules. Check the "Source" column to see which rules come from which sources.', 'rewrite-rules-inspector' ) . '</li>' .
+					'</ul>' .
+					'<p>' . __( '<strong>Tips:</strong>', 'rewrite-rules-inspector' ) . '</p>' .
+					'<ul>' .
+					'<li>' . __( 'Use the "Rule Source" filter to focus on specific types of rules.', 'rewrite-rules-inspector' ) . '</li>' .
+					'<li>' . __( 'Download the rules as a text file for offline analysis.', 'rewrite-rules-inspector' ) . '</li>' .
+					'<li>' . __( 'Check the permastructs section to understand the URL structure templates.', 'rewrite-rules-inspector' ) . '</li>' .
+					'</ul>',
+			)
+		);
+		
+		// Help sidebar.
+		$screen->set_help_sidebar(
+			'<p><strong>' . __( 'For more information:', 'rewrite-rules-inspector' ) . '</strong></p>' .
+			'<p><a href="https://wordpress.org/support/article/using-permalinks/" target="_blank">' . __( 'WordPress Permalinks Documentation', 'rewrite-rules-inspector' ) . '</a></p>' .
+			'<p><a href="https://developer.wordpress.org/reference/functions/add_rewrite_rule/" target="_blank">' . __( 'WordPress Rewrite API', 'rewrite-rules-inspector' ) . '</a></p>' .
+			'<p><a href="https://github.com/Automattic/Rewrite-Rules-Inspector" target="_blank">' . __( 'Plugin on GitHub', 'rewrite-rules-inspector' ) . '</a></p>'
+		);
 	}
 
 	/**


### PR DESCRIPTION
The admin interface is updated to display a new section for permastructs, allowing users to easily view and navigate to them.

Closes #7.

Also, add a contextual help tab to explain what the rewrite rules and permastructs are.

<img width="2395" height="1227" alt="Screenshot 2025-10-13 at 23 44 58" src="https://github.com/user-attachments/assets/4a52532c-e0ef-4e9c-ba02-1701711c31e4" />
