### PR TITLE
feat: Implement URL testing feature

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -342,3 +342,119 @@
 		background: transparent !important;
 	}
 }
+
+/* URL Test Results Styling */
+.rri-url-test-results {
+	margin: 20px 0;
+	padding: 20px;
+	background: #f9f9f9;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+}
+
+.rri-url-test-results h3 {
+	margin-top: 0;
+	color: #23282d;
+}
+
+.rri-test-summary p {
+	margin: 8px 0;
+}
+
+.rri-test-summary code {
+	background: #fff;
+	padding: 2px 6px;
+	border: 1px solid #ddd;
+	border-radius: 3px;
+	font-family: Consolas, Monaco, monospace;
+}
+
+.rri-first-match {
+	margin: 20px 0;
+}
+
+.rri-first-match h4 {
+	margin-bottom: 10px;
+	color: #23282d;
+}
+
+.rri-first-match table {
+	margin: 0;
+}
+
+.rri-first-match th {
+	width: 150px;
+	text-align: left;
+	vertical-align: top;
+	padding: 8px 12px;
+	background: #f1f1f1;
+	border-bottom: 1px solid #ddd;
+}
+
+.rri-first-match td {
+	padding: 8px 12px;
+	border-bottom: 1px solid #ddd;
+}
+
+.rri-first-match code {
+	background: #fff;
+	padding: 2px 6px;
+	border: 1px solid #ddd;
+	border-radius: 3px;
+	font-family: Consolas, Monaco, monospace;
+	display: inline-block;
+	margin: 2px 0;
+}
+
+.rri-all-matches {
+	margin: 20px 0;
+}
+
+.rri-all-matches h4 {
+	margin-bottom: 10px;
+	color: #23282d;
+}
+
+.rri-all-matches ol {
+	margin: 0;
+	padding-left: 20px;
+}
+
+.rri-all-matches li {
+	margin: 8px 0;
+}
+
+.rri-all-matches code {
+	background: #fff;
+	padding: 2px 6px;
+	border: 1px solid #ddd;
+	border-radius: 3px;
+	font-family: Consolas, Monaco, monospace;
+}
+
+.rri-match-source {
+	color: #666;
+	font-style: italic;
+	margin-left: 8px;
+}
+
+/* Filter form improvements */
+.rri-filter-row {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	flex-wrap: wrap;
+}
+
+.rri-filter-row label {
+	font-weight: 600;
+	margin-right: 5px;
+}
+
+.rri-filter-row input[type="text"] {
+	min-width: 300px;
+}
+
+.rri-filter-row select {
+	min-width: 120px;
+}

--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -35,6 +35,7 @@ require __DIR__ . '/src/Core/RewriteRules.php';
 require __DIR__ . '/src/Core/Permastructs.php';
 require __DIR__ . '/src/Core/FileExport.php';
 require __DIR__ . '/src/Core/RuleFlush.php';
+require __DIR__ . '/src/Core/UrlTester.php';
 
 // Load admin classes.
 require __DIR__ . '/src/Admin/AdminPage.php';

--- a/src/Admin/RewriteRulesTable.php
+++ b/src/Admin/RewriteRulesTable.php
@@ -209,29 +209,31 @@ final class RewriteRulesTable extends \WP_List_Table {
 				?>
 				<a href="<?php echo esc_url( $download_url ); ?>" class="button-secondary"><?php esc_html_e( 'Download', 'rewrite-rules-inspector' ); ?></a>
 			</div>
-			<form method="GET">
-				<label for="s"><?php esc_html_e( 'Match URL:', 'rewrite-rules-inspector' ); ?></label>
-				<input type="text" id="s" name="s" value="<?php echo esc_attr( $search ); ?>" size="50"/>
-				<input type="hidden" id="page" name="page" value="<?php echo esc_attr( $plugin_page ); ?>" />
-				<label for="source"><?php esc_html_e( 'Rule Source:', 'rewrite-rules-inspector' ); ?></label>
-				<select id="source" name="source">
-					<?php
-					$filter_source = 'all';
-					if ( isset( $_GET['source'] ) && in_array( $_GET['source'], $this->sources, true ) ) {
-						$filter_source = sanitize_key( $_GET['source'] );
-					}
+			<form method="GET" id="rri-filter-form">
+				<div class="rri-filter-row">
+					<label for="s"><?php esc_html_e( 'Test URL:', 'rewrite-rules-inspector' ); ?></label>
+					<input type="text" id="s" name="s" value="<?php echo esc_attr( $search ); ?>" size="50" placeholder="<?php esc_attr_e( 'Enter URL to test (e.g., /my-page/ or https://example.com/my-page/)', 'rewrite-rules-inspector' ); ?>"/>
+					<input type="hidden" id="page" name="page" value="<?php echo esc_attr( $plugin_page ); ?>" />
+					<label for="source"><?php esc_html_e( 'Rule Source:', 'rewrite-rules-inspector' ); ?></label>
+					<select id="source" name="source">
+						<?php
+						$filter_source = 'all';
+						if ( isset( $_GET['source'] ) && in_array( $_GET['source'], $this->sources, true ) ) {
+							$filter_source = sanitize_key( $_GET['source'] );
+						}
 
-					foreach ( $this->sources as $value ) {
-						echo '<option value="' . esc_attr( $value ) . '" ';
-						selected( $filter_source, $value );
-						echo '>' . esc_html( $value ) . '</option>';
-					}
-					?>
-				</select>
-				<?php submit_button( __( 'Filter', 'rewrite-rules-inspector' ), 'primary', null, false ); ?>
-				<?php if ( $search || ! empty( $_GET['source'] ) ) : ?>
-					<a href="<?php echo esc_url( menu_page_url( $plugin_page, false ) ); ?>" class="button-secondary"><?php esc_html_e( 'Reset', 'rewrite-rules-inspector' ); ?></a>
-				<?php endif; ?>
+						foreach ( $this->sources as $value ) {
+							echo '<option value="' . esc_attr( $value ) . '" ';
+							selected( $filter_source, $value );
+							echo '>' . esc_html( $value ) . '</option>';
+						}
+						?>
+					</select>
+					<?php submit_button( __( 'Test URL', 'rewrite-rules-inspector' ), 'primary', null, false ); ?>
+					<?php if ( $search || ! empty( $_GET['source'] ) ) : ?>
+						<a href="<?php echo esc_url( menu_page_url( $plugin_page, false ) ); ?>" class="button-secondary"><?php esc_html_e( 'Reset', 'rewrite-rules-inspector' ); ?></a>
+					<?php endif; ?>
+				</div>
 			</form>
 		</div>
 		<?php

--- a/src/Admin/ViewRenderer.php
+++ b/src/Admin/ViewRenderer.php
@@ -36,8 +36,9 @@ final class ViewRenderer {
 	 * @param array  $rules Array of rewrite rules.
 	 * @param array  $permastructs Array of permastructs.
 	 * @param object $wp_list_table WordPress list table object.
+	 * @param array  $url_test_results Optional URL test results.
 	 */
-	public function render_rules_view( array $rules, array $permastructs, $wp_list_table ): void {
+	public function render_rules_view( array $rules, array $permastructs, $wp_list_table, array $url_test_results = null ): void {
 		// Bump view stats or do something else on page load.
 		do_action( 'rri_view_rewrite_rules', $rules );
 
@@ -54,6 +55,10 @@ final class ViewRenderer {
 				</h2>
 
 				<?php $this->render_rules_messages( $rules ); ?>
+
+				<?php if ( $url_test_results ) : ?>
+					<?php $this->render_url_test_results( $url_test_results ); ?>
+				<?php endif; ?>
 
 				<?php $this->render_rules_description( $wp_list_table ); ?>
 
@@ -132,6 +137,93 @@ final class ViewRenderer {
 		if ( file_exists( $template_path ) ) {
 			include $template_path;
 		}
+	}
+
+	/**
+	 * Render URL test results.
+	 *
+	 * @since 1.5.0
+	 * @param array $results URL test results.
+	 */
+	private function render_url_test_results( array $results ): void {
+		?>
+		<div class="rri-url-test-results">
+			<h3><?php esc_html_e( 'URL Test Results', 'rewrite-rules-inspector' ); ?></h3>
+			
+			<div class="rri-test-summary">
+				<p><strong><?php esc_html_e( 'URL Tested:', 'rewrite-rules-inspector' ); ?></strong> <code><?php echo esc_html( $results['url'] ); ?></code></p>
+				<p><strong><?php esc_html_e( 'Path Tested:', 'rewrite-rules-inspector' ); ?></strong> <code><?php echo esc_html( $results['path'] ); ?></code></p>
+				
+				<?php if ( $results['is_404'] ) : ?>
+					<div class="notice notice-error">
+						<p><strong><?php esc_html_e( 'Result: 404 Error', 'rewrite-rules-inspector' ); ?></strong></p>
+						<p><?php 
+							printf(
+								/* translators: %d: Number of rules tested */
+								esc_html__( 'This URL does not match any of the %d rewrite rules and would result in a 404 error.', 'rewrite-rules-inspector' ),
+								$results['total_rules_tested']
+							);
+						?></p>
+					</div>
+				<?php else : ?>
+					<div class="notice notice-success">
+						<p><strong><?php esc_html_e( 'Result: Found Matching Rule(s)', 'rewrite-rules-inspector' ); ?></strong></p>
+						<p><?php 
+							printf(
+								/* translators: %d: Number of matches */
+								esc_html__( 'Found %d matching rule(s).', 'rewrite-rules-inspector' ),
+								count( $results['matches'] )
+							);
+						?></p>
+					</div>
+
+					<?php if ( $results['first_match'] ) : ?>
+						<div class="rri-first-match">
+							<h4><?php esc_html_e( 'First Match (WordPress will use this):', 'rewrite-rules-inspector' ); ?></h4>
+							<table class="widefat">
+								<tr>
+									<th><?php esc_html_e( 'Rule Pattern', 'rewrite-rules-inspector' ); ?></th>
+									<td><code><?php echo esc_html( $results['first_match']['rule'] ); ?></code></td>
+								</tr>
+								<tr>
+									<th><?php esc_html_e( 'Rewrite Target', 'rewrite-rules-inspector' ); ?></th>
+									<td><code><?php echo esc_html( $results['first_match']['rewrite'] ); ?></code></td>
+								</tr>
+								<tr>
+									<th><?php esc_html_e( 'Source', 'rewrite-rules-inspector' ); ?></th>
+									<td><?php echo esc_html( $results['first_match']['source'] ); ?></td>
+								</tr>
+								<?php if ( ! empty( $results['first_match']['query_vars'] ) ) : ?>
+									<tr>
+										<th><?php esc_html_e( 'Query Variables', 'rewrite-rules-inspector' ); ?></th>
+										<td>
+											<?php foreach ( $results['first_match']['query_vars'] as $key => $value ) : ?>
+												<code><?php echo esc_html( $key ); ?> = <?php echo esc_html( $value ); ?></code><br>
+											<?php endforeach; ?>
+										</td>
+									</tr>
+								<?php endif; ?>
+							</table>
+						</div>
+					<?php endif; ?>
+
+					<?php if ( count( $results['matches'] ) > 1 ) : ?>
+						<div class="rri-all-matches">
+							<h4><?php esc_html_e( 'All Matching Rules:', 'rewrite-rules-inspector' ); ?></h4>
+							<ol>
+								<?php foreach ( $results['matches'] as $index => $match ) : ?>
+									<li>
+										<code><?php echo esc_html( $match['rule'] ); ?></code>
+										<span class="rri-match-source">(<?php echo esc_html( $match['source'] ); ?>)</span>
+									</li>
+								<?php endforeach; ?>
+							</ol>
+						</div>
+					<?php endif; ?>
+				<?php endif; ?>
+			</div>
+		</div>
+		<?php
 	}
 
 	/**

--- a/src/Core/RewriteRules.php
+++ b/src/Core/RewriteRules.php
@@ -164,7 +164,20 @@ final class RewriteRules {
 		$match_path = '';
 		
 		if ( ! empty( $_GET['s'] ) ) {
-			$match_path                = wp_parse_url( esc_url( $_GET['s'] ), PHP_URL_PATH );
+			$input = sanitize_text_field( $_GET['s'] );
+			
+			// If the input doesn't start with http:// or https://, treat it as a path.
+			if ( ! preg_match( '/^https?:\/\//', $input ) ) {
+				$match_path = $input;
+			} else {
+				$match_path = wp_parse_url( esc_url( $input ), PHP_URL_PATH );
+			}
+			
+			// Ensure we have a string value.
+			if ( null === $match_path ) {
+				$match_path = '';
+			}
+			
 			$wordpress_subdir_for_site = wp_parse_url( home_url(), PHP_URL_PATH );
 			if ( ! empty( $wordpress_subdir_for_site ) ) {
 				$match_path = str_replace( $wordpress_subdir_for_site, '', $match_path );

--- a/src/Core/UrlTester.php
+++ b/src/Core/UrlTester.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Automattic\RewriteRulesInspector\Core;
+
+/**
+ * Service class for testing URLs against rewrite rules.
+ *
+ * @package Automattic\RewriteRulesInspector\Core
+ * @since 1.5.0
+ */
+final class UrlTester {
+
+	/**
+	 * Test a URL against a specific set of rewrite rules and return detailed match information.
+	 *
+	 * @since 1.5.0
+	 * @param string $url The URL to test.
+	 * @param array  $rules Array of rewrite rules to test against.
+	 * @return array Detailed test results.
+	 */
+	public function test_url_with_rules( string $url, array $rules ): array {
+		// Parse the URL to get the path component.
+		$parsed_url = wp_parse_url( $url );
+		$path = $parsed_url['path'] ?? '/';
+		
+		// If wp_parse_url returns null for path, treat the input as a path.
+		if ( null === $parsed_url['path'] && ! preg_match( '/^https?:\/\//', $url ) ) {
+			$path = $url;
+		}
+
+		// Remove WordPress subdirectory if the site is in a subdirectory.
+		$home_path = wp_parse_url( home_url(), PHP_URL_PATH );
+		if ( ! empty( $home_path ) ) {
+			$path = str_replace( $home_path, '', $path );
+		}
+
+		$path = ltrim( $path, '/' );
+
+		// Test against each rule and collect matches.
+		$matches = [];
+		$first_match = null;
+
+		foreach ( $rules as $rule => $data ) {
+			$rewrite = is_array( $data ) ? $data['rewrite'] : $data;
+			
+			if ( preg_match( sprintf( '#^%s#', $rule ), $path, $rule_matches ) ) {
+				$match_info = [
+					'rule' => $rule,
+					'rewrite' => $rewrite,
+					'matches' => $rule_matches,
+					'query_vars' => $this->extract_query_vars( $rewrite, $rule_matches ),
+					'source' => is_array( $data ) ? ( $data['source'] ?? 'other' ) : 'other',
+				];
+
+				$matches[] = $match_info;
+
+				// The first match is the one WordPress would use.
+				if ( null === $first_match ) {
+					$first_match = $match_info;
+				}
+			}
+		}
+
+		// Determine if this would result in a 404.
+		$is_404 = empty( $matches );
+
+		// Get the final query that WordPress would execute.
+		$final_query = null;
+		if ( $first_match ) {
+			$final_query = $this->build_final_query( $first_match['rewrite'], $first_match['matches'] );
+		}
+
+		return [
+			'url' => $url,
+			'path' => $path,
+			'is_404' => $is_404,
+			'matches' => $matches,
+			'first_match' => $first_match,
+			'final_query' => $final_query,
+			'total_rules_tested' => count( $rules ),
+		];
+	}
+
+	/**
+	 * Test a URL against all rewrite rules and return detailed match information.
+	 *
+	 * @since 1.5.0
+	 * @param string $url The URL to test.
+	 * @return array Detailed test results.
+	 */
+	public function test_url( string $url ): array {
+		global $wp_rewrite;
+
+		// Parse the URL to get the path component.
+		$parsed_url = wp_parse_url( $url );
+		$path = $parsed_url['path'] ?? '/';
+		
+		// If wp_parse_url returns null for path, treat the input as a path.
+		if ( null === $parsed_url['path'] && ! preg_match( '/^https?:\/\//', $url ) ) {
+			$path = $url;
+		}
+
+		// Remove WordPress subdirectory if the site is in a subdirectory.
+		$home_path = wp_parse_url( home_url(), PHP_URL_PATH );
+		if ( ! empty( $home_path ) ) {
+			$path = str_replace( $home_path, '', $path );
+		}
+
+		$path = ltrim( $path, '/' );
+
+		// Get all rewrite rules using the same method as RewriteRules service.
+		$rewrite_rules = get_option( 'rewrite_rules' );
+		if ( ! $rewrite_rules ) {
+			$rewrite_rules = [];
+		}
+
+		// Also check for missing rules that should be generated.
+		$maybe_missing = $wp_rewrite->rewrite_rules();
+		foreach ( $maybe_missing as $rule => $rewrite ) {
+			if ( ! array_key_exists( $rule, $rewrite_rules ) ) {
+				$rewrite_rules[ $rule ] = $rewrite;
+			}
+		}
+
+		// Test against each rule and collect matches.
+		$matches = [];
+		$first_match = null;
+
+		foreach ( $rewrite_rules as $rule => $rewrite ) {
+			if ( preg_match( sprintf( '#^%s#', $rule ), $path, $rule_matches ) ) {
+				$match_info = [
+					'rule' => $rule,
+					'rewrite' => $rewrite,
+					'matches' => $rule_matches,
+					'query_vars' => $this->extract_query_vars( $rewrite, $rule_matches ),
+					'source' => $this->get_rule_source( $rule, $rewrite ),
+				];
+
+				$matches[] = $match_info;
+
+				// The first match is the one WordPress would use.
+				if ( null === $first_match ) {
+					$first_match = $match_info;
+				}
+			}
+		}
+
+		// Determine if this would result in a 404.
+		$is_404 = empty( $matches );
+
+		// Get the final query that WordPress would execute.
+		$final_query = null;
+		if ( $first_match ) {
+			$final_query = $this->build_final_query( $first_match['rewrite'], $first_match['matches'] );
+		}
+
+		return [
+			'url' => $url,
+			'path' => $path,
+			'is_404' => $is_404,
+			'matches' => $matches,
+			'first_match' => $first_match,
+			'final_query' => $final_query,
+			'total_rules_tested' => count( $rewrite_rules ),
+		];
+	}
+
+	/**
+	 * Extract query variables from a rewrite rule.
+	 *
+	 * @since 1.5.0
+	 * @param string $rewrite The rewrite rule.
+	 * @param array  $matches The regex matches.
+	 * @return array Extracted query variables.
+	 */
+	private function extract_query_vars( string $rewrite, array $matches ): array {
+		$query_vars = [];
+
+		// Parse the rewrite rule to find query variable assignments.
+		if ( preg_match_all( '/([^=&]+)=([^&]+)/', $rewrite, $var_matches, PREG_SET_ORDER ) ) {
+			foreach ( $var_matches as $var_match ) {
+				$key = $var_match[1];
+				$value = $var_match[2];
+
+				// Replace $matches[n] with actual values.
+				$value = preg_replace_callback(
+					'/\$matches\[(\d+)\]/',
+					function ( $m ) use ( $matches ) {
+						$index = (int) $m[1];
+						return isset( $matches[ $index ] ) && $matches[ $index ] !== '' ? $matches[ $index ] : '';
+					},
+					$value
+				);
+
+				$query_vars[ $key ] = $value;
+			}
+		}
+
+		return $query_vars;
+	}
+
+	/**
+	 * Get the source of a rewrite rule.
+	 *
+	 * @since 1.5.0
+	 * @param string $rule The rewrite rule pattern.
+	 * @param string $rewrite The rewrite rule target.
+	 * @return string The rule source.
+	 */
+	private function get_rule_source( string $rule, string $rewrite ): string {
+		// This is a simplified version - in a full implementation,
+		// you'd want to use the same logic as RewriteRules::generate_rules_by_source()
+		// to determine the actual source.
+
+		// Common patterns to identify sources.
+		if ( strpos( $rewrite, 'category_name' ) !== false ) {
+			return 'category';
+		}
+		if ( strpos( $rewrite, 'tag=' ) !== false ) {
+			return 'post_tag';
+		}
+		if ( strpos( $rewrite, 'p=' ) !== false ) {
+			return 'post';
+		}
+		if ( strpos( $rewrite, 'page_id' ) !== false ) {
+			return 'page';
+		}
+		if ( strpos( $rewrite, 'author_name' ) !== false ) {
+			return 'author';
+		}
+		if ( strpos( $rewrite, 'year=' ) !== false ) {
+			return 'date';
+		}
+
+		return 'other';
+	}
+
+	/**
+	 * Build the final query string that WordPress would execute.
+	 *
+	 * @since 1.5.0
+	 * @param string $rewrite The rewrite rule.
+	 * @param array  $matches The regex matches.
+	 * @return string The final query string.
+	 */
+	private function build_final_query( string $rewrite, array $matches ): string {
+		// Replace $matches[n] with actual values.
+		$query = preg_replace_callback(
+			'/\$matches\[(\d+)\]/',
+			function ( $m ) use ( $matches ) {
+				$index = (int) $m[1];
+				return isset( $matches[ $index ] ) && $matches[ $index ] !== '' ? $matches[ $index ] : '';
+			},
+			$rewrite
+		);
+
+		return $query;
+	}
+
+	/**
+	 * Get a human-readable explanation of the test results.
+	 *
+	 * @since 1.5.0
+	 * @param array $results The test results from test_url().
+	 * @return string Human-readable explanation.
+	 */
+	public function explain_results( array $results ): string {
+		if ( $results['is_404'] ) {
+			return sprintf(
+				/* translators: %1$s: URL, %2$d: Number of rules tested */
+				__( 'The URL "%1$s" does not match any of the %2$d rewrite rules and would result in a 404 error.', 'rewrite-rules-inspector' ),
+				$results['url'],
+				$results['total_rules_tested']
+			);
+		}
+
+		$match_count = count( $results['matches'] );
+		$first_match = $results['first_match'];
+
+		if ( $match_count === 1 ) {
+			return sprintf(
+				/* translators: %1$s: URL, %2$s: Rule pattern */
+				__( 'The URL "%1$s" matches exactly one rewrite rule: %2$s', 'rewrite-rules-inspector' ),
+				$results['url'],
+				$first_match['rule']
+			);
+		}
+
+		return sprintf(
+			/* translators: %1$s: URL, %2$d: Number of matches, %3$s: First matching rule */
+			__( 'The URL "%1$s" matches %2$d rewrite rules. The first match (which WordPress will use) is: %3$s', 'rewrite-rules-inspector' ),
+			$results['url'],
+			$match_count,
+			$first_match['rule']
+		);
+	}
+
+	/**
+	 * Format test results for CLI output.
+	 *
+	 * @since 1.5.0
+	 * @param array $results The test results from test_url().
+	 * @param bool  $verbose Whether to include verbose output.
+	 * @return string Formatted CLI output.
+	 */
+	public function format_for_cli( array $results, bool $verbose = false ): string {
+		$output = [];
+
+		$output[] = sprintf( 'Testing URL: %s', $results['url'] );
+		$output[] = sprintf( 'Path tested: %s', $results['path'] );
+		$output[] = '';
+
+		if ( $results['is_404'] ) {
+			$output[] = '❌ Result: 404 (No matching rules found)';
+			$output[] = sprintf( 'Tested against %d rewrite rules', $results['total_rules_tested'] );
+		} else {
+			$output[] = '✅ Result: Found matching rule(s)';
+			$output[] = sprintf( 'Total matches: %d', count( $results['matches'] ) );
+			$output[] = '';
+
+			$first_match = $results['first_match'];
+			$output[] = 'First match (WordPress will use this):';
+			$output[] = sprintf( '  Rule: %s', $first_match['rule'] );
+			$output[] = sprintf( '  Rewrite: %s', $first_match['rewrite'] );
+			$output[] = sprintf( '  Source: %s', $first_match['source'] );
+
+			if ( $verbose && ! empty( $first_match['query_vars'] ) ) {
+				$output[] = '  Query variables:';
+				foreach ( $first_match['query_vars'] as $key => $value ) {
+					$output[] = sprintf( '    %s = %s', $key, $value );
+				}
+			}
+
+			if ( $verbose && count( $results['matches'] ) > 1 ) {
+				$output[] = '';
+				$output[] = 'All matching rules:';
+				foreach ( $results['matches'] as $index => $match ) {
+					$output[] = sprintf( '  %d. %s (source: %s)', $index + 1, $match['rule'], $match['source'] );
+				}
+			}
+		}
+
+		return implode( "\n", $output );
+	}
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,6 +8,7 @@ use Automattic\RewriteRulesInspector\Core\RewriteRules;
 use Automattic\RewriteRulesInspector\Core\Permastructs;
 use Automattic\RewriteRulesInspector\Core\FileExport;
 use Automattic\RewriteRulesInspector\Core\RuleFlush;
+use Automattic\RewriteRulesInspector\Core\UrlTester;
 use Automattic\RewriteRulesInspector\Admin\AdminPage;
 use Automattic\RewriteRulesInspector\Admin\ViewRenderer;
 use Automattic\RewriteRulesInspector\Admin\ContextualHelp;
@@ -78,6 +79,13 @@ final class Plugin {
 	private RuleFlush $rule_flush_service;
 
 	/**
+	 * URL tester service.
+	 *
+	 * @var UrlTester $url_tester_service
+	 */
+	private UrlTester $url_tester_service;
+
+	/**
 	 * Admin page handler.
 	 *
 	 * @var AdminPage $admin_page
@@ -117,6 +125,7 @@ final class Plugin {
 		$this->permastruct_service   = new Permastructs();
 		$this->file_export_service   = new FileExport( $this->view_cap );
 		$this->rule_flush_service    = new RuleFlush( $this->flushing_enabled, $this->view_cap );
+		$this->url_tester_service    = new UrlTester();
 		$this->view_renderer         = new ViewRenderer( plugin_dir_path( __DIR__ ) );
 		$this->help_service          = new ContextualHelp();
 		$this->admin_page            = new AdminPage( $this->parent_slug, $this->page_slug, $this->view_cap, [ $this, 'view_rules' ], $this->help_service );
@@ -133,6 +142,7 @@ final class Plugin {
 		
 		// Register and enqueue admin styles.
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_styles' ] );
+
 	}
 
 	/**
@@ -223,7 +233,15 @@ final class Plugin {
 		$wp_list_table = new RewriteRulesTable( $rules, $sources, $this->flushing_enabled );
 		$wp_list_table->prepare_items();
 
-		$this->view_renderer->render_rules_view( $rules, $permastructs, $wp_list_table );
+		// Test URL if one is provided.
+		$url_test_results = null;
+		if ( ! empty( $_GET['s'] ) ) {
+			$url = sanitize_text_field( $_GET['s'] );
+			// Use the same filtered rules for URL testing to ensure consistency.
+			$url_test_results = $this->url_tester_service->test_url_with_rules( $url, $rules );
+		}
+
+		$this->view_renderer->render_rules_view( $rules, $permastructs, $wp_list_table, $url_test_results );
 	}
 
 	/**
@@ -245,5 +263,16 @@ final class Plugin {
 		global $plugin_page;
 		$redirect_url = menu_page_url( $plugin_page, false );
 		$this->rule_flush_service->flush_rules( $redirect_url );
+	}
+
+
+	/**
+	 * Get the URL tester service.
+	 *
+	 * @since 1.5.0
+	 * @return UrlTester The URL tester service.
+	 */
+	public function get_url_tester(): UrlTester {
+		return $this->url_tester_service;
 	}
 }


### PR DESCRIPTION
## What's New

This PR introduces a comprehensive URL testing service that significantly improves upon the existing "Match URL" filter functionality.

## The Problem

The previous "Match URL" feature was limited - it only filtered the rules table to show rules that *might* match a URL, but didn't provide:
- Clear indication of which rule actually matches first
- Resolved query variables from regex captures
- Explanation of why URLs return 404 errors
- Visual feedback about match results

## The Solution

**New URL Testing Service:**
- **Comprehensive testing**: Tests URLs against all rewrite rules and shows detailed match information
- **Visual results**: Clear success/error indicators with detailed explanations
- **Query variable resolution**: Shows actual values instead of `$matches[1]` placeholders
- **404 debugging**: Explains why URLs don't match any rules
- **Multiple match handling**: Shows all matching rules when multiple patterns match

**Enhanced UI:**
- Improved form with better labeling ("Test URL" vs "Match URL")
- Dedicated results section with clear visual hierarchy
- Consistent rule counts between test results and rules table
- Better styling and user experience

### Key Improvements

| Before | After |
|--------|-------|
| Simple rule filtering | Comprehensive URL testing with detailed results |
| Shows `$matches[1]` | Shows resolved values like `pagename=foo` |
| No 404 explanation | Clear 404 debugging with rule count |
| Basic filtering | Visual success/error indicators |
| Inconsistent results | Synchronized rule sets between test and table |

### Technical Details

- **New `UrlTester` service**: Handles URL parsing, rule matching, and query variable resolution
- **Enhanced `ViewRenderer`**: Displays detailed test results with proper styling
- **Improved `RewriteRules` service**: Better path handling for various URL formats
- **Robust error handling**: Works with `/foo`, `foo`, or full URLs without errors

This enhancement transforms the plugin from a basic rule inspector into a powerful URL debugging tool that helps developers understand exactly how WordPress processes their URLs.

Here's the new URL tester in action:

https://github.com/user-attachments/assets/173be516-f44c-4b6f-b0ad-90a9cd3107fa

