### PR TITLE
fix: implicitly marking parameter as nullable is deprecated

### DIFF
--- a/src/Admin/ViewRenderer.php
+++ b/src/Admin/ViewRenderer.php
@@ -38,7 +38,7 @@ final class ViewRenderer {
 	 * @param object $wp_list_table WordPress list table object.
 	 * @param array  $url_test_results Optional URL test results.
 	 */
-	public function render_rules_view( array $rules, array $permastructs, $wp_list_table, array $url_test_results = null ): void {
+	public function render_rules_view( array $rules, array $permastructs, $wp_list_table, ?array $url_test_results = null ): void {
 		// Bump view stats or do something else on page load.
 		do_action( 'rri_view_rewrite_rules', $rules );
 


### PR DESCRIPTION
The recent update broke compatibility with PHP 8.4 by introducing an implicitly nullable parameter in `ViewRenderer::render_rules_view()`.

This behavior was [deprecated](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types) in [PHP 8.4](https://www.php.net/releases/8.4/en.php#deprecations_and_bc_breaks).

This PR fixes the declaration to make it compatible with PHP 8.4.
