### PR TITLE
refactor: Update UI to use tabs navigation

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -34,33 +34,11 @@
 }
 
 /* ==========================================================================
-   Navigation and Jump Links
+   Tabs
    ========================================================================== */
-
-.jump-link {
-	display: inline-block;
-	margin-left: var(--rri-spacing-sm);
-	padding: 1px 4px;
-	background: transparent;
-	border: none;
-	border-radius: 2px;
-	text-decoration: none;
-	color: #666;
-	font-size: 12px;
-	font-weight: normal;
-	transition: color 0.15s ease;
-}
-
-.jump-link:hover,
-.jump-link:focus {
-	color: var(--rri-primary-color);
-	text-decoration: none;
-	background: transparent;
-}
-
-.jump-link:focus {
-	outline: 1px solid var(--rri-primary-color);
-	outline-offset: 1px;
+/* WordPress provides base styles for .nav-tab-wrapper and .nav-tab */
+.nav-tab-wrapper {
+	margin-bottom: 12px;
 }
 
 /* ==========================================================================
@@ -144,7 +122,20 @@
 .custom-tablenav-top .tablenav-actions {
 	float: right;
 	display: flex;
+	align-items: center;
 	gap: var(--rri-spacing-sm);
+}
+
+.rri-rules-count {
+	color: #666;
+	font-size: 13px;
+	margin-right: var(--rri-spacing-sm);
+}
+
+/* Priority column should be narrow */
+.column-priority {
+	width: 60px;
+	text-align: center;
 }
 
 .custom-tablenav-top form {
@@ -247,11 +238,6 @@
 		padding: 2px 4px;
 	}
 	
-	.jump-link {
-		display: inline-block;
-		margin-left: var(--rri-spacing-sm);
-		margin-top: 0;
-	}
 }
 
 @media (max-width: 600px) {
@@ -350,6 +336,29 @@
 	background: #f9f9f9;
 	border: 1px solid #ddd;
 	border-radius: 4px;
+}
+
+/* Notices kept inside the tab content to avoid core relocation */
+.rri-notice {
+    /* Match core .notice spacing */
+    margin: 5px 0 15px;
+    padding: 12px;
+    background: #fff;
+    border-left: 4px solid #72aee6; /* info color default */
+    box-shadow: 0 1px 1px rgba(0,0,0,.04);
+    color: #1d2327;
+}
+
+.rri-notice p {
+    margin: .5em 0;
+}
+
+.rri-notice-success {
+    border-left-color: #46b450; /* core success */
+}
+
+.rri-notice-error {
+    border-left-color: #dc3232; /* core error */
 }
 
 .rri-url-test-results h3 {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -12,76 +12,18 @@
 	 * Initialize admin functionality when document is ready.
 	 */
 	$(document).ready(function() {
-		initSmoothScrolling();
 		initAccessibilityEnhancements();
 	});
 
-	/**
-	 * Initialize smooth scrolling for jump links.
-	 */
-	function initSmoothScrolling() {
-		// Check if user prefers reduced motion.
-		const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-		
-		if (prefersReducedMotion) {
-			return; // Skip smooth scrolling if user prefers reduced motion.
-		}
-
-		// Handle jump link clicks.
-		$('.jump-link').on('click', function(e) {
-			const href = $(this).attr('href');
-			
-			// Only handle internal anchor links.
-			if (href && href.startsWith('#')) {
-				e.preventDefault();
-				
-				const target = $(href);
-				if (target.length) {
-					// Calculate offset for WordPress admin toolbar.
-					const adminBarHeight = $('#wpadminbar').length ? $('#wpadminbar').outerHeight() : 0;
-					const offset = adminBarHeight + 20; // 20px additional spacing
-					
-					// Smooth scroll to target.
-					$('html, body').animate({
-						scrollTop: target.offset().top - offset
-					}, 500, 'swing');
-					
-					// Add focus to target for accessibility.
-					target.focus();
-					
-					// Add a temporary highlight effect (subtle).
-					target.addClass('rri-highlight');
-					setTimeout(function() {
-						target.removeClass('rri-highlight');
-					}, 1500);
-				}
-			}
-		});
-	}
 
 	/**
 	 * Initialize accessibility enhancements.
 	 */
 	function initAccessibilityEnhancements() {
-		// Add keyboard navigation support for jump links.
-		$('.jump-link').on('keydown', function(e) {
-			// Handle Enter and Space key presses.
-			if (e.which === 13 || e.which === 32) { // Enter or Space
-				e.preventDefault();
-				$(this).click();
-			}
-		});
-
 		// Add ARIA live region for dynamic content updates.
 		if (!$('#rri-live-region').length) {
 			$('body').append('<div id="rri-live-region" class="screen-reader-text" aria-live="polite" aria-atomic="true"></div>');
 		}
-
-		// Announce section changes when jumping.
-		$('.jump-link').on('click', function() {
-			const targetText = $(this).text();
-			$('#rri-live-region').text('Navigated to ' + targetText);
-		});
 	}
 
 	/**
@@ -96,39 +38,5 @@
 			rect.right <= (window.innerWidth || document.documentElement.clientWidth)
 		);
 	}
-
-	/**
-	 * Add scroll spy functionality for better navigation.
-	 */
-	function initScrollSpy() {
-		const sections = $('.rri-section h2[id]');
-		
-		if (sections.length < 2) {
-			return; // No need for scroll spy with less than 2 sections.
-		}
-
-		$(window).on('scroll', function() {
-			let current = '';
-			
-			sections.each(function() {
-				if (isInViewport(this)) {
-					current = $(this).attr('id');
-				}
-			});
-			
-			// Update active state of jump links.
-			$('.jump-link').removeClass('rri-active');
-			if (current) {
-				$('.jump-link[href="#' + current + '"]').addClass('rri-active');
-			}
-		});
-	}
-
-	// Initialize scroll spy if there are multiple sections.
-	$(document).ready(function() {
-		if ($('.rri-section').length > 1) {
-			initScrollSpy();
-		}
-	});
 
 })(jQuery);

--- a/src/Admin/RewriteRulesTable.php
+++ b/src/Admin/RewriteRulesTable.php
@@ -130,25 +130,30 @@ final class RewriteRulesTable extends \WP_List_Table {
 	 */
 	public function display() {
 		$this->display_tablenav( 'top' );
-		?>
-		<table class="wp-list-table <?php echo esc_attr( implode( ' ', $this->get_table_classes() ) ); ?>">
-			<thead>
-				<tr>
-					<?php $this->print_column_headers(); ?>
-				</tr>
-			</thead>
+		
+		// Only show the table if there are items to display
+		if ( $this->has_items() ) {
+			?>
+			<table class="wp-list-table <?php echo esc_attr( implode( ' ', $this->get_table_classes() ) ); ?>">
+				<thead>
+					<tr>
+						<?php $this->print_column_headers(); ?>
+					</tr>
+				</thead>
 
-			<tbody id="the-list"<?php echo $this->has_items() ? " data-wp-lists='list:{$this->_args['singular']}'" : ''; ?>>
-				<?php $this->display_rows_or_placeholder(); ?>
-			</tbody>
+				<tbody id="the-list"<?php echo " data-wp-lists='list:{$this->_args['singular']}'"; ?>>
+					<?php $this->display_rows_or_placeholder(); ?>
+				</tbody>
 
-			<tfoot>
-				<tr>
-					<?php $this->print_column_headers( false ); ?>
-				</tr>
-			</tfoot>
-		</table>
-		<?php
+				<tfoot>
+					<tr>
+						<?php $this->print_column_headers( false ); ?>
+					</tr>
+				</tfoot>
+			</table>
+			<?php
+		}
+		
 		$this->display_tablenav( 'bottom' );
 	}
 
@@ -168,6 +173,28 @@ final class RewriteRulesTable extends \WP_List_Table {
 		?>
 		<div class="custom-tablenav-top">
 			<div class="tablenav-actions">
+				<?php
+				// Show rules count for current selection
+				$count = count( $this->items );
+				$has_url_filter = ! empty( $_GET['s'] );
+				$has_source_filter = isset( $_GET['source'] ) && 'all' !== $_GET['source'];
+				
+				if ( $has_url_filter || $has_source_filter ) {
+					$count_text = sprintf(
+						/* translators: %d: Number of rules */
+						_n( '%d rule for this selection', '%d rules for this selection', $count, 'rewrite-rules-inspector' ),
+						$count
+					);
+				} else {
+					$count_text = sprintf(
+						/* translators: %d: Number of rules */
+						_n( '%d rule total', '%d rules total', $count, 'rewrite-rules-inspector' ),
+						$count
+					);
+				}
+				?>
+				<span class="rri-rules-count"><?php echo esc_html( $count_text ); ?></span>
+				
 				<?php
 				// Only show the flush button if enabled.
 				if ( $this->flushing_enabled ) :
@@ -212,7 +239,7 @@ final class RewriteRulesTable extends \WP_List_Table {
 			<form method="GET" id="rri-filter-form">
 				<div class="rri-filter-row">
 					<label for="s"><?php esc_html_e( 'Test URL:', 'rewrite-rules-inspector' ); ?></label>
-					<input type="text" id="s" name="s" value="<?php echo esc_attr( $search ); ?>" size="50" placeholder="<?php esc_attr_e( 'Enter URL to test (e.g., /my-page/ or https://example.com/my-page/)', 'rewrite-rules-inspector' ); ?>"/>
+					<input type="text" id="s" name="s" value="<?php echo esc_attr( $search ); ?>" size="50" placeholder="<?php esc_attr_e( 'Enter URL (e.g., /my-page/ or https://example.com/my-page/)', 'rewrite-rules-inspector' ); ?>"/>
 					<input type="hidden" id="page" name="page" value="<?php echo esc_attr( $plugin_page ); ?>" />
 					<label for="source"><?php esc_html_e( 'Rule Source:', 'rewrite-rules-inspector' ); ?></label>
 					<select id="source" name="source">
@@ -248,9 +275,10 @@ final class RewriteRulesTable extends \WP_List_Table {
 	 */
 	public function get_columns(): array {
 		return [
-			'rule'    => __( 'Rule', 'rewrite-rules-inspector' ),
-			'rewrite' => __( 'Rewrite', 'rewrite-rules-inspector' ),
-			'source'  => __( 'Source', 'rewrite-rules-inspector' ),
+			'priority' => __( 'Priority', 'rewrite-rules-inspector' ),
+			'rule'     => __( 'Rule', 'rewrite-rules-inspector' ),
+			'rewrite'  => __( 'Rewrite', 'rewrite-rules-inspector' ),
+			'source'   => __( 'Source', 'rewrite-rules-inspector' ),
 		];
 	}
 
@@ -260,8 +288,10 @@ final class RewriteRulesTable extends \WP_List_Table {
 	 * @since 1.0.0
 	 */
 	public function display_rows() {
+		$priority = 1;
 		foreach ( $this->items as $rule => $data ) {
-			$this->single_row( [ $rule, $data ] );
+			$this->single_row( [ $rule, $data, $priority ] );
+			$priority++;
 		}
 	}
 
@@ -272,9 +302,12 @@ final class RewriteRulesTable extends \WP_List_Table {
 	 * @param array $item The current row's data.
 	 */
 	public function single_row( $item ) {
-		[ $rule, $data ] = $item;
+		[ $rule, $data, $priority ] = $item;
 		?>
 		<tr>
+			<td class="column-priority">
+				<?php echo esc_html( $priority ); ?>
+			</td>
 			<td class="column-rule">
 				<code><?php echo esc_html( $rule ); ?></code>
 			</td>

--- a/src/Admin/ViewRenderer.php
+++ b/src/Admin/ViewRenderer.php
@@ -38,35 +38,61 @@ final class ViewRenderer {
 	 * @param object $wp_list_table WordPress list table object.
 	 * @param array  $url_test_results Optional URL test results.
 	 */
-	public function render_rules_view( array $rules, array $permastructs, $wp_list_table, ?array $url_test_results = null ): void {
+	public function render_rules_view( array $rules, array $permastructs, $wp_list_table, ?array $url_test_results = null, bool $flush_success = false ): void {
 		// Bump view stats or do something else on page load.
 		do_action( 'rri_view_rewrite_rules', $rules );
+
+		// Determine current tab.
+		$has_permastructs = ! empty( $permastructs );
+		$default_tab      = 'rules';
+		$current_tab      = isset( $_GET['tab'] ) ? sanitize_key( (string) $_GET['tab'] ) : $default_tab;
+		if ( ! $has_permastructs && 'permastructs' === $current_tab ) {
+			$current_tab = $default_tab;
+		}
 
 		?>
 		<div class="wrap rri-admin-page">
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 
-			<div class="rri-section">
-				<h2 id="rewrite-rules-section">
-					<?php esc_html_e( 'Rewrite Rules', 'rewrite-rules-inspector' ); ?>
-					<?php if ( ! empty( $permastructs ) ) : ?>
-						<a href="#permastructs-section" class="jump-link"><?php esc_html_e( 'Jump to Permastructs', 'rewrite-rules-inspector' ); ?></a>
+			<nav class="nav-tab-wrapper" aria-label="<?php esc_attr_e( 'Rewrite Rules Inspector sections', 'rewrite-rules-inspector' ); ?>">
+				<?php
+					$rules_url = add_query_arg( 'tab', 'rules' );
+					$rules_cls = 'nav-tab' . ( 'rules' === $current_tab ? ' nav-tab-active' : '' );
+					printf(
+						'<a href="%1$s" class="%2$s">%3$s</a>',
+						esc_url( $rules_url ),
+						esc_attr( $rules_cls ),
+						esc_html__( 'Rewrite Rules', 'rewrite-rules-inspector' )
+					);
+
+					if ( $has_permastructs ) {
+						$perma_url = add_query_arg( 'tab', 'permastructs' );
+						$perma_cls = 'nav-tab' . ( 'permastructs' === $current_tab ? ' nav-tab-active' : '' );
+						printf(
+							'<a href="%1$s" class="%2$s">%3$s</a>',
+							esc_url( $perma_url ),
+							esc_attr( $perma_cls ),
+							esc_html__( 'Permastructs', 'rewrite-rules-inspector' )
+						);
+					}
+				?>
+			</nav>
+
+			<?php if ( 'rules' === $current_tab ) : ?>
+				<div class="rri-section" id="rewrite-rules-section" tabindex="-1">
+					<h2 class="screen-reader-text"><?php esc_html_e( 'Rewrite Rules', 'rewrite-rules-inspector' ); ?></h2>
+					<?php if ( $flush_success ) : ?>
+						<?php $this->render_flush_success_message(); ?>
 					<?php endif; ?>
-				</h2>
-
-				<?php $this->render_rules_messages( $rules ); ?>
-
-				<?php if ( $url_test_results ) : ?>
-					<?php $this->render_url_test_results( $url_test_results ); ?>
-				<?php endif; ?>
-
-				<?php $this->render_rules_description( $wp_list_table ); ?>
-
-				<?php $wp_list_table->display(); ?>
-			</div>
-
-			<?php if ( ! empty( $permastructs ) ) : ?>
-				<div class="rri-section">
+					<?php $this->render_rules_messages( $rules ); ?>
+					<?php if ( $url_test_results ) : ?>
+						<?php $this->render_url_test_results( $url_test_results ); ?>
+					<?php endif; ?>
+					<?php $wp_list_table->display(); ?>
+				</div>
+			<?php elseif ( 'permastructs' === $current_tab && $has_permastructs ) : ?>
+				<div class="rri-section" id="permastructs-section" tabindex="-1">
+					<h2 class="screen-reader-text"><?php esc_html_e( 'Permastructs', 'rewrite-rules-inspector' ); ?></h2>
 					<?php $this->render_permastructs_table( $permastructs ); ?>
 				</div>
 			<?php endif; ?>
@@ -88,43 +114,21 @@ final class ViewRenderer {
 			}
 		}
 
+		$has_filter = isset( $_GET['source'] ) && 'all' !== $_GET['source'];
+
 		if ( empty( $rules ) ) {
-			$error_message = apply_filters( 'rri_message_no_rules', __( 'No rewrite rules yet, try flushing.', 'rewrite-rules-inspector' ) );
-			echo '<div class="message error"><p>' . wp_kses_post( $error_message ) . '</p></div>';
+			// With a rule source filter active, suppress the top-level notice to keep URL Test Results position consistent.
+			if ( ! $has_filter ) {
+				$error_message = apply_filters( 'rri_message_no_rules', __( 'No rewrite rules yet, try flushing.', 'rewrite-rules-inspector' ) );
+				echo '<div class="rri-notice rri-notice-error" role="status" aria-live="polite"><p>' . wp_kses_post( $error_message ) . '</p></div>';
+			}
 		} elseif ( $missing_count > 0 ) {
 			/* translators: %d: Count of missing rewrite rules */
 			$error_message = apply_filters( 'rri_message_missing_rules', sprintf( _n( '%d rewrite rule may be missing, try flushing.', '%d rewrite rules may be missing, try flushing.', $missing_count, 'rewrite-rules-inspector' ), $missing_count ) );
-			echo '<div class="message error"><p>' . wp_kses_post( $error_message ) . '</p></div>';
+			echo '<div class="rri-notice rri-notice-error" role="status" aria-live="polite"><p>' . wp_kses_post( $error_message ) . '</p></div>';
 		}
 	}
 
-	/**
-	 * Render rules description text.
-	 *
-	 * @since 1.5.0
-	 * @param object $wp_list_table WordPress list table object.
-	 */
-	private function render_rules_description( $wp_list_table ): void {
-		if ( ! empty( $_GET['s'] ) ) {
-			?>
-			<p>
-				<?php
-				/* translators: %s: Count of rewrite rules */
-				printf( wp_kses_post( __( 'A listing of all %1$s rewrite rules for this site that match "<a target="_blank" href="%2$s">%2$s</a>"', 'rewrite-rules-inspector' ) ), count( $wp_list_table->items ), esc_url( $_GET['s'] ) );
-				?>
-			</p>
-			<?php
-		} else {
-			?>
-			<p>
-				<?php
-				/* translators: %s: Count of rewrite rules */
-				printf( esc_html__( 'A listing of all %1$s rewrite rules for this site.', 'rewrite-rules-inspector' ), count( $wp_list_table->items ) );
-				?>
-			</p>
-			<?php
-		}
-	}
 
 	/**
 	 * Render the permastructs table.
@@ -154,28 +158,45 @@ final class ViewRenderer {
 				<p><strong><?php esc_html_e( 'URL Tested:', 'rewrite-rules-inspector' ); ?></strong> <code><?php echo esc_html( $results['url'] ); ?></code></p>
 				<p><strong><?php esc_html_e( 'Path Tested:', 'rewrite-rules-inspector' ); ?></strong> <code><?php echo esc_html( $results['path'] ); ?></code></p>
 				
-				<?php if ( $results['is_404'] ) : ?>
-					<div class="notice notice-error">
-						<p><strong><?php esc_html_e( 'Result: 404 Error', 'rewrite-rules-inspector' ); ?></strong></p>
-						<p><?php 
-							printf(
-								/* translators: %d: Number of rules tested */
-								esc_html__( 'This URL does not match any of the %d rewrite rules and would result in a 404 error.', 'rewrite-rules-inspector' ),
-								$results['total_rules_tested']
-							);
-						?></p>
-					</div>
-				<?php else : ?>
-					<div class="notice notice-success">
-						<p><strong><?php esc_html_e( 'Result: Found Matching Rule(s)', 'rewrite-rules-inspector' ); ?></strong></p>
-						<p><?php 
-							printf(
-								/* translators: %d: Number of matches */
-								esc_html__( 'Found %d matching rule(s).', 'rewrite-rules-inspector' ),
-								count( $results['matches'] )
-							);
-						?></p>
-					</div>
+				<?php
+					$tested_count = (int) $results['total_rules_tested'];
+					$has_filter = isset( $_GET['source'] ) && 'all' !== $_GET['source'];
+					// If a filter yields zero rules to test, show a concise message here to keep layout consistent.
+					if ( $has_filter && 0 === $tested_count ) : ?>
+						<div class="rri-first-match">
+							<h4><?php esc_html_e( 'No rewrite rules match the selected rule source.', 'rewrite-rules-inspector' ); ?></h4>
+						</div>
+					<?php endif; 
+					// Only show 404 notice for URLs that would actually result in a 404
+					// Skip for homepage, admin URLs, and other special cases
+					$tested_path = trim( $results['path'], '/' );
+					$is_special_url = empty( $tested_path ) || strpos( $tested_path, 'wp-admin' ) === 0 || strpos( $tested_path, 'wp-content' ) === 0 || strpos( $tested_path, 'wp-includes' ) === 0;
+					
+					if ( $results['is_404'] && $tested_count > 0 && ! $is_special_url ) : ?>
+						<div class="rri-notice rri-notice-error" role="status" aria-live="polite">
+							<p><strong><?php esc_html_e( 'Result: 404 Error', 'rewrite-rules-inspector' ); ?></strong></p>
+							<p><?php 
+								printf(
+									/* translators: %d: Number of rules tested */
+									esc_html__( 'This URL does not match any of the %d rewrite rules and would result in a 404 error.', 'rewrite-rules-inspector' ),
+									$tested_count
+								);
+							?></p>
+						</div>
+					<?php elseif ( $results['is_404'] && $tested_count > 0 && $is_special_url ) : ?>
+						<div class="rri-notice" role="status" aria-live="polite">
+							<p><strong><?php esc_html_e( 'Result: No matching rules', 'rewrite-rules-inspector' ); ?></strong></p>
+							<p><?php 
+								printf(
+									/* translators: %d: Number of rules tested */
+									esc_html__( 'This URL does not match any of the %d rewrite rules, but it may be handled by WordPress core routing.', 'rewrite-rules-inspector' ),
+									$tested_count
+								);
+							?></p>
+						</div>
+					<?php endif; ?>
+
+				<?php if ( ! $results['is_404'] ) : ?>
 
 					<?php if ( $results['first_match'] ) : ?>
 						<div class="rri-first-match">
@@ -197,9 +218,30 @@ final class ViewRenderer {
 									<tr>
 										<th><?php esc_html_e( 'Query Variables', 'rewrite-rules-inspector' ); ?></th>
 										<td>
-											<?php foreach ( $results['first_match']['query_vars'] as $key => $value ) : ?>
-												<code><?php echo esc_html( $key ); ?> = <?php echo esc_html( $value ); ?></code><br>
-											<?php endforeach; ?>
+											<?php 
+											$query_vars = $results['first_match']['query_vars'];
+											
+											// Handle both string and array formats
+											if ( is_string( $query_vars ) ) {
+												// Remove index.php? prefix if present
+												$query_string = $query_vars;
+												if ( strpos( $query_string, 'index.php?' ) === 0 ) {
+													$query_string = substr( $query_string, 10 );
+												}
+												echo '<code>' . esc_html( $query_string ) . '</code>';
+											} else {
+												// Array format - show key-value pairs, removing index.php? prefix from keys
+												foreach ( $query_vars as $key => $value ) : 
+													// Remove index.php? prefix from key if present
+													$clean_key = $key;
+													if ( strpos( $key, 'index.php?' ) === 0 ) {
+														$clean_key = substr( $key, 10 );
+													}
+												?>
+													<code><?php echo esc_html( $clean_key ); ?> = <?php echo esc_html( $value ); ?></code><br>
+												<?php endforeach;
+											}
+											?>
 										</td>
 									</tr>
 								<?php endif; ?>
@@ -209,15 +251,14 @@ final class ViewRenderer {
 
 					<?php if ( count( $results['matches'] ) > 1 ) : ?>
 						<div class="rri-all-matches">
-							<h4><?php esc_html_e( 'All Matching Rules:', 'rewrite-rules-inspector' ); ?></h4>
-							<ol>
-								<?php foreach ( $results['matches'] as $index => $match ) : ?>
-									<li>
-										<code><?php echo esc_html( $match['rule'] ); ?></code>
-										<span class="rri-match-source">(<?php echo esc_html( $match['source'] ); ?>)</span>
-									</li>
-								<?php endforeach; ?>
-							</ol>
+							<h4><?php esc_html_e( 'Additional Matching Rules:', 'rewrite-rules-inspector' ); ?></h4>
+							<p><?php 
+								printf(
+									/* translators: %d: Number of additional matches */
+									esc_html__( 'See the table below for all %d matching rules in priority order.', 'rewrite-rules-inspector' ),
+									count( $results['matches'] )
+								);
+							?></p>
 						</div>
 					<?php endif; ?>
 				<?php endif; ?>
@@ -232,6 +273,6 @@ final class ViewRenderer {
 	 * @since 1.5.0
 	 */
 	public function render_flush_success_message(): void {
-		echo '<div class="message updated"><p>' . esc_html__( 'Rewrite rules flushed.', 'rewrite-rules-inspector' ) . '</p></div>';
+		echo '<div class="rri-notice rri-notice-success" role="status" aria-live="polite"><p>' . esc_html__( 'Rewrite rules flushed.', 'rewrite-rules-inspector' ) . '</p></div>';
 	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -172,8 +172,6 @@ final class Plugin {
 			add_action( 'admin_init', [ $this, 'download_rules' ] );
 		} elseif ( isset( $_GET['page'], $_GET['action'] ) && $_GET['page'] === $this->page_slug && 'flush-rules' === $_GET['action'] ) {
 			add_action( 'admin_init', [ $this, 'flush_rules' ] );
-		} elseif ( isset( $_GET['page'], $_GET['message'] ) && $_GET['page'] === $this->page_slug && 'flush-success' === $_GET['message'] ) {
-			add_action( 'admin_notices', [ $this, 'action_admin_notices' ] );
 		}
 	}
 
@@ -212,15 +210,6 @@ final class Plugin {
 	}
 
 	/**
-	 * Show a message when you've successfully flushed your rewrite rules.
-	 *
-	 * @since 1.1.0
-	 */
-	public function action_admin_notices(): void {
-		$this->view_renderer->render_flush_success_message();
-	}
-
-	/**
 	 * View the rewrite rules for the site.
 	 *
 	 * @since 1.0.0
@@ -240,8 +229,9 @@ final class Plugin {
 			// Use the same filtered rules for URL testing to ensure consistency.
 			$url_test_results = $this->url_tester_service->test_url_with_rules( $url, $rules );
 		}
+		$flush_success = ( isset( $_GET['message'] ) && 'flush-success' === $_GET['message'] );
 
-		$this->view_renderer->render_rules_view( $rules, $permastructs, $wp_list_table, $url_test_results );
+		$this->view_renderer->render_rules_view( $rules, $permastructs, $wp_list_table, $url_test_results, $flush_success );
 	}
 
 	/**

--- a/views/permastructs-table.php
+++ b/views/permastructs-table.php
@@ -16,7 +16,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <h2 id="permastructs-section">
 	<?php esc_html_e( 'Permastructs', 'rewrite-rules-inspector' ); ?>
-	<a href="#rewrite-rules-section" class="jump-link"><?php esc_html_e( 'Jump to Rewrite Rules', 'rewrite-rules-inspector' ); ?></a>
 </h2>
 
 <p>


### PR DESCRIPTION
Closes #54.

- Removed jump link styles and functionality in favor of tab navigation.
- Added new styles for tab navigation and notices.
- Focus on keeping content accessible.
- Enhanced the Rewrite Rules table with a priority column and rules count display, allowing simplification of the URL Test Results
- Updated ViewRenderer to handle success messages and improved error handling for URL tests.
- Adjusted the display logic to ensure proper rendering of rules and permastructs sections.

## Screenshots

<img width="2394" height="746" alt="Screenshot 2025-10-14 at 16 52 02" src="https://github.com/user-attachments/assets/8f90b324-f0f5-4ad4-9f48-ab3044321959" />
<img width="2394" height="488" alt="Screenshot 2025-10-14 at 16 51 54" src="https://github.com/user-attachments/assets/2747bc42-0695-4c8e-bf5d-9fe19c01412d" />
<img width="2394" height="983" alt="Screenshot 2025-10-14 at 16 51 33" src="https://github.com/user-attachments/assets/5e839430-5630-43e2-9e56-e17ed7b52e5e" />
<img width="2394" height="983" alt="Screenshot 2025-10-14 at 16 51 20" src="https://github.com/user-attachments/assets/3f5b2b05-8f1d-45a4-b90d-0ed10512e7b9" />
<img width="2394" height="983" alt="Screenshot 2025-10-14 at 16 51 03" src="https://github.com/user-attachments/assets/6af7d258-11e7-44fd-9860-99003a601b98" />
<img width="2394" height="983" alt="Screenshot 2025-10-14 at 16 50 51" src="https://github.com/user-attachments/assets/c595cfe7-1a39-4188-ade6-ce4c359f506a" />
