### PR TITLE
Bump minimum WordPress version to 6.4

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -39,7 +39,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding these custom sniff properties:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
-	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<!-- Rules: WordPress VIP - see
 		https://github.com/Automattic/VIP-Coding-Standards -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rewrite Rules Inspector
 
 Stable tag: 1.5.1  
-Requires at least: 5.9  
+Requires at least: 6.4  
 Tested up to: 6.8  
 Requires PHP: 7.4  
 License: GPLv2 or later  

--- a/rewrite-rules-inspector.php
+++ b/rewrite-rules-inspector.php
@@ -12,14 +12,14 @@
  * Plugin URI:        https://wordpress.org/plugins/rewrite-rules-inspector/
  * Description:       Simple WordPress admin tool for inspecting your rewrite rules.
  * Version:           1.5.1
+ * Requires at least: 6.4
+ * Requires PHP:      7.4
  * Author:            Automattic, Daniel Bachhuber
  * Author URI:        https://automattic.com/
  * Text Domain:       rewrite-rules-inspector
  * License:           GPL-2.0-or-later
  * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
  * GitHub Plugin URI: https://github.com/Automattic/Rewrite-Rules-Inspector
- * Requires PHP:      7.4
- * Requires WP:       5.9.0
  */
 
 define( 'REWRITE_RULES_INSPECTOR_VERSION', '1.5.1' ); // Unused for now.


### PR DESCRIPTION
Update minimum supported WordPress version from 5.9 to 6.4.