### PR TITLE
chore: add .gitattributes and update .distignore for cleaner releases

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,7 @@
 # Directories
 /.git/
 /.github/
+/.wordpress-org/
 /bin/
 /node_modules/
 /tests/
@@ -20,3 +21,4 @@ composer.lock
 package.json
 package-lock.json
 phpunit.xml.dist
+rector.php

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Directories
+/.git/                  export-ignore
+/.github/               export-ignore
+/.wordpress-org/        export-ignore
+/bin/                   export-ignore
+/node_modules/          export-ignore
+/tests/                 export-ignore
+/vendor/                export-ignore
+
+# Files
+.distignore             export-ignore
+.editorconfig           export-ignore
+.gitattributes          export-ignore
+.gitignore              export-ignore
+.phpcs.xml.dist         export-ignore
+.wp-env.json            export-ignore
+.wp-env.override.json   export-ignore
+CHANGELOG.md            export-ignore
+composer.json           export-ignore
+composer.lock           export-ignore
+package.json            export-ignore
+package-lock.json       export-ignore
+phpunit.xml.dist        export-ignore
+rector.php              export-ignore


### PR DESCRIPTION
## Summary

The 1.6.0 release ZIP included files that should have been excluded:
- `rector.php`
- `phpunit.xml.dist`
- `composer.json`
- `.wp-env.json`
- `.wordpress-org/`
- `.phpcs.xml.dist`
- `.gitignore`
- `.github/`
- `.editorconfig`
- `.distignore`

This PR:
- Adds `.gitattributes` with `export-ignore` entries to exclude dev files from GitHub release ZIPs
- Updates `.distignore` to add missing `/.wordpress-org/` and `rector.php` for WordPress.org deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)